### PR TITLE
Remove reference to non-existent variables in CUDA verbose output

### DIFF
--- a/HostCUDA.cu
+++ b/HostCUDA.cu
@@ -638,8 +638,7 @@ void TreePieceCellListDataTransferRemoteResume(CudaRequest *data){
   transfer = gravityKernel->buffers[ILCELL_IDX].transfer_to_device;
 
 #ifdef CUDA_VERBOSE_KERNEL_ENQUEUE
-  printf("(%d) TRANSFER REMOTE RESUME CELL %d (%d)\n", CmiMyPe(),
-        size, transfer);
+  printf("(%d) TRANSFER REMOTE RESUME CELL (%d)\n", CmiMyPe(), transfer);
 #endif
 
   gravityKernel->addBuffer(data->missedNodes, data->sMissed, transfer, false,
@@ -837,9 +836,8 @@ void TreePiecePartListDataTransferRemoteResume(CudaRequest *data){
         transfer = gravityKernel->buffers[ILPART_IDX].transfer_to_device;
 
 #ifdef CUDA_VERBOSE_KERNEL_ENQUEUE
-        printf("(%d) TRANSFER REMOTE RESUME PART %zu (%d)\n",
+        printf("(%d) TRANSFER REMOTE RESUME PART (%d)\n",
             CmiMyPe(),
-            size,
             transfer
             );
 #endif


### PR DESCRIPTION
The 'size' variables were removed during code refactoring in 8234a97 and 8f4b45a.