### PR TITLE
Clean up printf format warnings

### DIFF
--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -7,6 +7,7 @@
 #include "DataManager.h"
 #include "Reductions.h"
 #include "formatted_string.h"
+#include <iomanip>
 
 #ifdef CUDA
 #include "hapi.h"
@@ -117,7 +118,7 @@ void DataManager::acceptFinalKeys(const SFC::Key* keys, const int* responsible, 
     std::vector<SFC::Key>::iterator iter3;
     CkPrintf("Keys:");
     for(iter3=boundaryKeys.begin();iter3!=boundaryKeys.end();iter3++){
-      CkPrintf("%016llx,",*iter3);
+      CkPrintf("%016llx,", static_cast<unsigned long long>(*iter3));
     }
     CkPrintf("\n");
   }
@@ -493,10 +494,10 @@ void DataManager::serializeLocalTree(){
     treePiecesDone = 0;
 
     if(verbosity > 1)
-        CkPrintf("[%d] Registered tree pieces length: %d\n", CkMyPe(), registeredTreePieces.length());
+        CkPrintf("[%d] Registered tree pieces length: %lu\n", CkMyPe(), registeredTreePieces.length());
     serializeLocal(root);
     if(verbosity > 1)
-        CkPrintf("[%d] Registered tree pieces length after serialize local: %d\n", CkMyPe(), registeredTreePieces.length());
+        CkPrintf("[%d] Registered tree pieces length after serialize local: %lu\n", CkMyPe(), registeredTreePieces.length());
   }
   CmiUnlock(__nodelock);
 
@@ -529,7 +530,7 @@ void DataManager::startLocalWalk() {
 /// The data for remote interactions is on the GPU, so continue the
 /// remote walk.
 void DataManager::resumeRemoteChunk() {
-  if(verbosity > 1) CkPrintf("[%d] resumeRemoteChunk registered: %d\n", CkMyPe(), registeredTreePieces.length());
+  if(verbosity > 1) CkPrintf("[%d] resumeRemoteChunk registered: %lu\n", CkMyPe(), registeredTreePieces.length());
   int chunk = 0;
   chunk = currentChunkBuffers->chunk;
   delete currentChunkBuffers->moments;

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -7,7 +7,6 @@
 #include "DataManager.h"
 #include "Reductions.h"
 #include "formatted_string.h"
-#include <iomanip>
 
 #ifdef CUDA
 #include "hapi.h"

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -117,7 +117,7 @@ void DataManager::acceptFinalKeys(const SFC::Key* keys, const int* responsible, 
     std::vector<SFC::Key>::iterator iter3;
     CkPrintf("Keys:");
     for(iter3=boundaryKeys.begin();iter3!=boundaryKeys.end();iter3++){
-      CkPrintf("%016llx,", static_cast<unsigned long long>(*iter3));
+      CkPrintf("%s,", make_formatted_string(*iter3).c_str());
     }
     CkPrintf("\n");
   }

--- a/InOutput.cpp
+++ b/InOutput.cpp
@@ -223,7 +223,7 @@ void TreePiece::loadTipsy(const std::string& filename,
 	    startParticle += excess;
 	    }
 	if(startParticle >= nTotalParticles) {
-	    CkError("Bad startParticle: %d, nPart: %d, myIndex: %d, nLoading: %d\n",
+	    CkError("Bad startParticle: %ld, nPart: %ld, myIndex: %d, nLoading: %d\n",
 		    startParticle, nTotalParticles, myIndex, numLoadingPEs);
 	    }
 	CkAssert(startParticle < nTotalParticles);
@@ -890,7 +890,7 @@ void TreePiece::loadNChilada(const std::string& filename,
 	    startParticle += excess;
 	    }
 	if(startParticle >= nTotalParticles) {
-	    CkError("Bad startParticle: %d, nPart: %d, myIndex: %d, nLoading: %d\n",
+	    CkError("Bad startParticle: %ld, nPart: %ld, myIndex: %d, nLoading: %d\n",
 		    startParticle, nTotalParticles, myIndex, numLoadingPEs);
 	    }
 	CkAssert(startParticle < nTotalParticles);
@@ -1603,7 +1603,7 @@ void TreePiece::ioShuffle(CkReductionMsg *msg)
 
 
 	    if (verbosity>=3)
-		CkPrintf("me:%d to:%d how many:%d\n",thisIndex, iPiece,
+		CkPrintf("me:%d to:%d how many:%ld\n",thisIndex, iPiece,
 			 (binEnd-binBegin));
 	    if(iPiece == thisIndex) {
 		ioAcceptSortedParticles(shuffleMsg);

--- a/MultistepLB.cpp
+++ b/MultistepLB.cpp
@@ -248,7 +248,7 @@ void MultistepLB::work2(BaseLB::LDStats *stats, int count){
   int nmig = stats->n_migrateobjs;
 
   if (_lb_args.debug()>=2) {
-    CkPrintf("[work2] %d objects allocating %d bytes for tp\n", nmig, nmig*sizeof(TPObject));
+    CkPrintf("[work2] %d objects allocating %lu bytes for tp\n", nmig, nmig*sizeof(TPObject));
   }
   CkPrintf("[ORB3D] objects total %d active %d\n", numobjs,nmig);
 
@@ -294,7 +294,7 @@ void MultistepLB::work2(BaseLB::LDStats *stats, int count){
   int numnodes = nx*ny*nz;
 
   if (_lb_args.debug()>=2) {
-    CkPrintf("[work2] %d numnodes allocating %d bytes for nodes\n", numnodes, numnodes*sizeof(Node));
+    CkPrintf("[work2] %d numnodes allocating %lu bytes for nodes\n", numnodes, numnodes*sizeof(Node));
   }
   Node *nodes = new Node[numnodes];
 

--- a/Orb3dLB.cpp
+++ b/Orb3dLB.cpp
@@ -107,7 +107,7 @@ void Orb3dLB::work(BaseLB::LDStats* stats)
 {
   int numobjs = stats->n_objs;
 
-  CkPrintf("[orb3dlb] %d objects allocating %d bytes for tp\n", numobjs, numobjs*sizeof(TPObject));
+  CkPrintf("[orb3dlb] %d objects allocating %lu bytes for tp\n", numobjs, numobjs*sizeof(TPObject));
   tps.resize(numobjs);
 
   for(int i = 0; i < numobjs; i++){
@@ -161,7 +161,7 @@ void Orb3dLB::work(BaseLB::LDStats* stats)
   int nz = tmgr.getDimNZ();
   int numnodes = nx*ny*nz;
 
-  CkPrintf("[orb3dlb] %d numnodes allocating %d bytes for nodes\n", numnodes, numnodes*sizeof(Node));
+  CkPrintf("[orb3dlb] %d numnodes allocating %lu bytes for nodes\n", numnodes, numnodes*sizeof(Node));
   nodes.resize(numnodes);
 
   for(int i = 0; i < stats->count; i++){

--- a/Orb3dLBCommon.h
+++ b/Orb3dLBCommon.h
@@ -142,7 +142,7 @@ class Orb3dCommon{
             else{
               int fromPE = (*from)[orb.lbindex];
               if (fromPE < 0 || fromPE >= procload.size()) {
-                CkPrintf("[%d] trying to access fromPe %d nprocs %d\n", CkMyPe(), fromPE, procload.size());
+                CkPrintf("[%d] trying to access fromPe %d nprocs %lu\n", CkMyPe(), fromPE, procload.size());
                 CkAbort("Trying to access a PE which is outside the range\n");
               }
               procload[fromPE] += ev.load;

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2032,7 +2032,7 @@ void Main::advanceBigStep(int iStep) {
 	nSink = *(int *) msgCnt->getData();
 	delete msgCnt;
 	if(nSink != 0)
-	    CkPrintf("Sink number of Sinks: nSink = %d\n", nSink);
+	    CkPrintf("Sink number of Sinks: nSink = %ld\n", nSink);
 	}
 
     ckout << "\nStep: " << (iStep + ((double) currentStep)/MAXSUBSTEPS)

--- a/SIDM.cpp
+++ b/SIDM.cpp
@@ -114,7 +114,7 @@ void SIDMSmoothParams::fcnSmooth(GravityParticle *p, int nSmooth, pqSmoothNode *
  
         if (probability > .1 && ran>0.99999) {
            CkPrintf("SIDM Warning! The probability is rather large: %g \n",probability);
-           CkPrintf("iOrder: %i, dDelta: %g,  dvcosmo: %g, Sigma: %g  \n",p->iOrder,dDelta,dvcosmo, Sigma);
+           CkPrintf("iOrder: %ld, dDelta: %g,  dvcosmo: %g, Sigma: %g  \n",p->iOrder,dDelta,dvcosmo, Sigma);
            CkPrintf("fnorm: %g, kern: %g, r2: %g, q->mass: %g, aaa: %g  \n",fNorm,KERNEL( r2, nSmooth ),r2,(q->mass),(a*a*a*2.0));
            }
 

--- a/Sorter.cpp
+++ b/Sorter.cpp
@@ -515,12 +515,12 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
     CkPrintf("\n");
     CkPrintf("Nodekeys:");
     for(int j=0;j<nodeKeys.size();j++)
-      ckout << make_formatted_string(nodeKeys[j]).c_str() << ',';
+      CkPrintf("%s,", make_formatted_string(nodeKeys[j]).c_str());
     CkPrintf("\n");
     if (nodesOpened.size() > 0) {
       CkPrintf("Nodes opened (%lu):",nodesOpened.size());
       for (int j=0;j<nodesOpened.size();j++)
-        ckout << make_formatted_string(nodesOpened[j]).c_str() << ',';
+        CkPrintf("%s,", make_formatted_string(nodesOpened[j]).c_str());
       CkPrintf("\n");
     }
   }
@@ -535,7 +535,7 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
   if(verbosity>=3){
     CkPrintf("Nodekeys after (%lu):",nodeKeys.size());
     for(int i=0;i<nodeKeys.size();i++)
-      ckout << nodeKeys[i] << ',';
+      CkPrintf("%s,", make_formatted_string(nodeKeys[i]).c_str());
     CkPrintf("\n");
   }
   if(histogram){

--- a/Sorter.cpp
+++ b/Sorter.cpp
@@ -151,9 +151,9 @@ void Sorter::finishPhase(CkReductionMsg *m){
   if(numChares == orbData.size()){ //Move data around
     for(i=0;i<numChares;i++){
 	if(verbosity > 2) {
-	    CkPrintf("%d has %d particles\n",i,binCounts[i]);
-	    CkPrintf("%d has %d gas particles\n",i,binCountsGas[i]);
-	    CkPrintf("%d has %d star particles\n",i,binCountsStar[i]);
+	    CkPrintf("%d has %lu particles\n",i,binCounts[i]);
+	    CkPrintf("%d has %du gas particles\n",i,binCountsGas[i]);
+	    CkPrintf("%d has %du star particles\n",i,binCountsStar[i]);
 	    }
 	treeProxy[i].initBeforeORBSend(binCounts[i], binCountsGas[i],
 				       binCountsStar[i], sortingCallback,
@@ -514,12 +514,12 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
     CkPrintf("\n");
     CkPrintf("Nodekeys:");
     for(int j=0;j<nodeKeys.size();j++)
-      CkPrintf("%llx,",nodeKeys[j]);
+      ckout << nodeKeys[j] << ',';
     CkPrintf("\n");
     if (nodesOpened.size() > 0) {
-      CkPrintf("Nodes opened (%d):",nodesOpened.size());
+      CkPrintf("Nodes opened (%lu):",nodesOpened.size());
       for (int j=0;j<nodesOpened.size();j++)
-        CkPrintf("%llx,",nodesOpened[j]);
+        ckout << nodesOpened[j] << ',';
       CkPrintf("\n");
     }
   }
@@ -532,9 +532,9 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
   delete m;
 
   if(verbosity>=3){
-    CkPrintf("Nodekeys after (%d):",nodeKeys.size());
+    CkPrintf("Nodekeys after (%lu):",nodeKeys.size());
     for(int i=0;i<nodeKeys.size();i++)
-      CkPrintf("%llx,",nodeKeys[i]);
+      ckout << nodeKeys[i] << ',';
     CkPrintf("\n");
   }
   if(histogram){
@@ -602,7 +602,7 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
         root->combine(joinThreshold, nodeKeys, binCounts);
 
 	if(binCounts.size() > numTreePieces) {
-	    CkPrintf("bumping joinThreshold: %d, size: %d\n", joinThreshold,
+	    CkPrintf("bumping joinThreshold: %d, size: %lu\n", joinThreshold,
 		     binCounts.size());
 	    joinThreshold = (int) (1.1*joinThreshold) + 1;
 	    }
@@ -656,7 +656,7 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
     //We also have the final bin counts
 		
     if(binCounts.size() > numTreePieces){
-      CkPrintf("Need %d tree pieces, available %d\n", binCounts.size(), numTreePieces);
+      CkPrintf("Need %lu tree pieces, available %u\n", binCounts.size(), numTreePieces);
       CkAbort("too few tree pieces\n");
     }
 

--- a/Sorter.cpp
+++ b/Sorter.cpp
@@ -971,7 +971,7 @@ void Sorter::adjustSplitters() {
                if(verbosity >=4 ) {
                   CkPrintf("Keys:");
                   for (std::vector<Key>::iterator  it = splitters.begin(); it < splitters.end(); it++) {
-                    CkPrintf("%lx,", *it);
+                    CkPrintf("%s,", make_formatted_string(*it).c_str());
                   }
                   CkPrintf("\n");
                 }

--- a/Sorter.cpp
+++ b/Sorter.cpp
@@ -152,8 +152,8 @@ void Sorter::finishPhase(CkReductionMsg *m){
     for(i=0;i<numChares;i++){
 	if(verbosity > 2) {
 	    CkPrintf("%d has %lu particles\n",i,binCounts[i]);
-	    CkPrintf("%d has %du gas particles\n",i,binCountsGas[i]);
-	    CkPrintf("%d has %du star particles\n",i,binCountsStar[i]);
+	    CkPrintf("%d has %u gas particles\n",i,binCountsGas[i]);
+	    CkPrintf("%d has %u star particles\n",i,binCountsStar[i]);
 	    }
 	treeProxy[i].initBeforeORBSend(binCounts[i], binCountsGas[i],
 				       binCountsStar[i], sortingCallback,

--- a/Sorter.cpp
+++ b/Sorter.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 
 #include "Sorter.h"
+#include "formatted_string.h"
 
 using std::vector;
 using std::list;
@@ -514,12 +515,12 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
     CkPrintf("\n");
     CkPrintf("Nodekeys:");
     for(int j=0;j<nodeKeys.size();j++)
-      ckout << nodeKeys[j] << ',';
+      ckout << make_formatted_string(nodeKeys[j]).c_str() << ',';
     CkPrintf("\n");
     if (nodesOpened.size() > 0) {
       CkPrintf("Nodes opened (%lu):",nodesOpened.size());
       for (int j=0;j<nodesOpened.size();j++)
-        ckout << nodesOpened[j] << ',';
+        ckout << make_formatted_string(nodesOpened[j]).c_str() << ',';
       CkPrintf("\n");
     }
   }

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3258,9 +3258,8 @@ bool TreePiece::sendFillReqNodeWhenNull(CkCacheRequestMsg<KeyType> *msg) {
     int first, last;
     bool bIsShared = nodeOwnership(msg->key, first, last);
     if(verbosity > 1) {
-        CkPrintf("fillRequest empty piece %d: %d %d %d ", thisIndex,
-            first, last, bIsShared);
-        ckout << msg->key << '\n';
+        CkPrintf("fillRequest empty piece %d: %d %d %d %s\n", thisIndex,
+            first, last, bIsShared, make_formatted_string(msg->key).c_str());
         CkPrintf("fillRequest resp. pieces %d: %d %d\n", thisIndex,
                    getResponsibleIndex(first, first),
                    getResponsibleIndex(last, last));

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -5564,8 +5564,10 @@ void TreePiece::combineKeys(Tree::NodeKey key,int bucket){
     bucketcheckList[bucket].erase(bucketcheckList[bucket].find(key));
     bucketcheckList[bucket].erase(iter);
     if(bucket == TEST_BUCKET && thisIndex == TEST_TP){
-      CkPrintf("[%d] combine(%ld, %ld)\n", thisIndex, key, sibKey);
-      CkPrintf("[%d] add(%ld, %ld)\n", thisIndex, key >> 1, sibKey);
+      CkPrintf("[%d] combine(%s, %s)\n", thisIndex, make_formatted_string(key).c_str(),
+               make_formatted_string(sibKey).c_str());
+      CkPrintf("[%d] add(%s, %s)\n", thisIndex, make_formatted_string(key >> 1).c_str(),
+               make_formatted_string(sibKey).c_str());
     }
     key >>= 1;
     bucketcheckList[bucket].insert(key);
@@ -5591,7 +5593,7 @@ void TreePiece::checkWalkCorrectness(){
       someWrong = true;
       CkPrintf("Error: [%d] Not all nodes were traversed by bucket %d\n",thisIndex,i);
       for (std::multiset<Tree::NodeKey>::iterator iter=bucketcheckList[i].begin(); iter != bucketcheckList[i].end(); iter++) {
-	CkPrintf("       [%d] key %ld\n",thisIndex,*iter);
+	    CkPrintf("       [%d] key %s\n",thisIndex,make_formatted_string(*iter).c_str());
       }
     }
     else { bucketcheckList[i].clear(); }
@@ -6414,12 +6416,12 @@ void TreePiece::finishWalk()
 
 #endif
 #ifdef HAPI_TRACE
-  CkPrintf("[%d] (%d) HAPI_TRACE localnode: %ld\n", thisIndex, activeRung, localNodeInteractions);
-  CkPrintf("[%d] (%d) HAPI_TRACE remotenode: %ld\n", thisIndex, activeRung, remoteNodeInteractions);
-  CkPrintf("[%d] (%d) HAPI_TRACE remoteresumenode: %ld\n", thisIndex, activeRung, remoteResumeNodeInteractions);
-  CkPrintf("[%d] (%d) HAPI_TRACE localpart: %ld\n", thisIndex, activeRung, localPartInteractions);
-  CkPrintf("[%d] (%d) HAPI_TRACE remotepart: %ld\n", thisIndex, activeRung, remotePartInteractions);
-  CkPrintf("[%d] (%d) HAPI_TRACE remoteresumepart: %ld\n", thisIndex, activeRung, remoteResumePartInteractions);
+  CkPrintf("[%d] (%d) HAPI_TRACE localnode: %lld\n", thisIndex, activeRung, localNodeInteractions);
+  CkPrintf("[%d] (%d) HAPI_TRACE remotenode: %lld\n", thisIndex, activeRung, remoteNodeInteractions);
+  CkPrintf("[%d] (%d) HAPI_TRACE remoteresumenode: %lld\n", thisIndex, activeRung, remoteResumeNodeInteractions);
+  CkPrintf("[%d] (%d) HAPI_TRACE localpart: %lld\n", thisIndex, activeRung, localPartInteractions);
+  CkPrintf("[%d] (%d) HAPI_TRACE remotepart: %lld\n", thisIndex, activeRung, remotePartInteractions);
+  CkPrintf("[%d] (%d) HAPI_TRACE remoteresumepart: %lld\n", thisIndex, activeRung, remoteResumePartInteractions);
   
 #endif
 

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -288,7 +288,7 @@ void TreePiece::sendORBParticles(){
 	    if(myBinCountsORB[nCounts+i] > 0) {
 		pGasOut = new extraSPHData[myBinCountsORB[nCounts+i]];
 		if (verbosity>=3)
-		  CkPrintf("me:%d to:%d nPart :%d, nGas:%d\n", thisIndex, i,
+		  CkPrintf("me:%d to:%d nPart :%ld, nGas:%d\n", thisIndex, i,
 			   *iter2 - *iter, myBinCountsORB[nCounts+i]);
 		int iGasOut = 0;
 		for(GravityParticle *pPart = *iter; pPart < *iter2; pPart++) {
@@ -3258,8 +3258,9 @@ bool TreePiece::sendFillReqNodeWhenNull(CkCacheRequestMsg<KeyType> *msg) {
     int first, last;
     bool bIsShared = nodeOwnership(msg->key, first, last);
     if(verbosity > 1) {
-        CkPrintf("fillRequest empty piece %d: %d %d %d %llx\n", thisIndex,
-            first, last, bIsShared, msg->key);
+        CkPrintf("fillRequest empty piece %d: %d %d %d ", thisIndex,
+            first, last, bIsShared);
+        ckout << msg->key << '\n';
         CkPrintf("fillRequest resp. pieces %d: %d %d\n", thisIndex,
                    getResponsibleIndex(first, first),
                    getResponsibleIndex(last, last));
@@ -5565,7 +5566,7 @@ void TreePiece::combineKeys(Tree::NodeKey key,int bucket){
     bucketcheckList[bucket].erase(iter);
     if(bucket == TEST_BUCKET && thisIndex == TEST_TP){
       CkPrintf("[%d] combine(%ld, %ld)\n", thisIndex, key, sibKey);
-      CkPrintf("[%d] add %ld\n", thisIndex, key >> 1, sibKey);
+      CkPrintf("[%d] add(%ld, %ld)\n", thisIndex, key >> 1, sibKey);
     }
     key >>= 1;
     bucketcheckList[bucket].insert(key);

--- a/formatted_string.h
+++ b/formatted_string.h
@@ -155,3 +155,30 @@ formatted_string<Args...> make_formatted_string(char const *format,
                                                 Args... args) {
   return formatted_string<Args...>(format, args...);
 }
+
+/**
+ * \brief A convenience overload for handling 128-bit integers
+ * \param ui An unsigned 128-bit integer using the charm++ type
+ *
+ * Support for 128-bit integers does not exist in all compilers
+ * and is not part of standard C++, so there are no format specifiers
+ * or iostream objects that will process them. Here, we split the
+ * 128-bit integer into two 64-bit integers and proceed.
+ */
+inline formatted_string<uint64_t, uint64_t> make_formatted_string(CmiUInt16 ui) {
+	const auto lq = static_cast<uint64_t>(ui); // lower quad word
+	const auto uq = static_cast<uint64_t>(ui>>64UL); // upper quad word
+	return formatted_string<uint64_t, uint64_t>{"%016lx%016lx", uq, lq};
+}
+
+/**
+ * \brief A convenience overload for handling 64-bit integers
+ * \param ui An unsigned 64-bit integer using the charm++ type
+ *
+ * This is a symmetric counterpart to the 128-bit version that
+ * is present only to simplify handling of types which are either
+ * 64- or 128-bit depending on compile-time configuration (e.g., NodeKey).
+ */
+inline formatted_string<uint64_t> make_formatted_string(CmiUInt8 ui) {
+	return formatted_string<uint64_t>{"%016lx", static_cast<uint64_t>(ui)};
+}

--- a/sinks.cpp
+++ b/sinks.cpp
@@ -303,7 +303,7 @@ void Main::SetSink()
 	treeProxy.SetSink(param.sinks.dSinkMassMin,
 			  CkCallbackResumeThread((void*&)msg));
 	nSink = *(int *)msg->getData();
-	if (verbosity) CkPrintf("Identified %d sink particles\n", nSink);
+	if (verbosity) CkPrintf("Identified %ld sink particles\n", nSink);
 	delete msg;
 	}
     }
@@ -406,11 +406,11 @@ void Main::FormSinks(double dTime, double dDelta, int iKickRung)
 
 
     if (verbosity)
-	CkPrintf("Sinks Formation: %i candidates +%d sinks\n",nCandidates,
+	CkPrintf("Sinks Formation: %i candidates +%ld sinks\n",nCandidates,
 		 nSinkAdd);
 
     dsec = CkWallTimer() - sec;
-    CkPrintf("Sink Form Done (+%d total) Calculated, Wallclock: %f secs\n\n",
+    CkPrintf("Sink Form Done (+%ld total) Calculated, Wallclock: %g secs\n\n",
 	     nSinkAdd, dsec);
 
     }


### PR DESCRIPTION
In the case where the precision depends upon a compile-time constant, the C-style printf was converted to using a formatted_string. This was done to simplify the code needed to get correct output for arbitrary types.