### PR TITLE
Remove REDUCTION_HELPER macro

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -125,7 +125,7 @@ defines := $(strip @HEXADECAPOLE@ @FLAG_RTFORCE@ @FLAG_ARCH@  \
           @FLAG_VSIGVISC@ @FLAG_DAMPING@ @FLAG_DIFFHARMONIC@  \
           @FLAG_TREE_BUILD@ $(debug_defines) @FLAG_INTERLIST@ \
           @FLAG_NSMOOTHINNER@ @FLAG_SPLITGAS@ @FLAG_SIDMINTERACT@ \
-          @FLAG_SUPERBUBBLE@ $(cuda_defines) -DREDUCTION_HELPER)
+          @FLAG_SUPERBUBBLE@ $(cuda_defines))
 
 modules := $(strip -language charm++ -balancer @DEFAULT_LB@   \
             $(foreach m,$(charm_modules),-module $(m))        \

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -9,9 +9,7 @@ mainmodule ParallelGravity {
   readonly CProxy_Main mainChare;
   readonly int verbosity;
   readonly CProxy_TreePiece treeProxy;
-#ifdef REDUCTION_HELPER
   readonly CProxy_ReductionHelper reductionHelperProxy;
-#endif
   readonly CProxy_LvArray lvProxy;
   readonly CProxy_LvArray smoothProxy;
   readonly CProxy_LvArray gravityProxy;
@@ -203,7 +201,6 @@ mainmodule ParallelGravity {
     entry [notrace] void off(CkCallback);                     
   };                                                          
 
-#ifdef REDUCTION_HELPER
   group [migratable] ReductionHelper {
     entry ReductionHelper();
     entry void countTreePieces(const CkCallback &cb);
@@ -211,7 +208,6 @@ mainmodule ParallelGravity {
 
     entry void evaluateBoundaries(const CkBitVector &binsToSplit, const CkCallback& cb);
   };
-#endif
 
   chare [migratable] Sorter {
     entry Sorter();

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -63,9 +63,7 @@ CProxy_Main mainChare;
 int verbosity;
 int bVDetails;
 CProxy_TreePiece treeProxy; ///< Proxy for the TreePiece chare array
-#ifdef REDUCTION_HELPER
 CProxy_ReductionHelper reductionHelperProxy;
-#endif
 CProxy_LvArray lvProxy;	    ///< Proxy for the liveViz array
 CProxy_LvArray smoothProxy; ///< Proxy for smooth reductions
 CProxy_LvArray gravityProxy; ///< Proxy for gravity reductions
@@ -1337,9 +1335,7 @@ Main::Main(CkArgMsg* m) {
         prjgrp = CProxy_ProjectionsControl::ckNew();
 
 	treeProxy = pieces;
-#ifdef REDUCTION_HELPER
         reductionHelperProxy = CProxy_ReductionHelper::ckNew();
-#endif
 	opts.bindTo(treeProxy);
 	lvProxy = CProxy_LvArray::ckNew(opts);
 	// Create an array for the smooth reductions

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -144,9 +144,7 @@ extern double dGlassDamper;
 extern int bUseCkLoopPar;
 extern GenericTrees useTree;
 extern CProxy_TreePiece treeProxy;
-#ifdef REDUCTION_HELPER
 extern CProxy_ReductionHelper reductionHelperProxy;
-#endif
 extern CProxy_LvArray lvProxy;	    // Proxy for the liveViz array
 extern CProxy_LvArray smoothProxy;  // Proxy for smooth reduction
 extern CProxy_LvArray gravityProxy; // Proxy for gravity reduction
@@ -1148,10 +1146,9 @@ private:
 
 	/// The counts of how many particles belonging to other
 	/// TreePieces I currently hold
-#ifndef REDUCTION_HELPER
 	CkVec<int64_t> myBinCounts;
-#endif
 	std::vector<int> myBinCountsORB;
+
 	/// My index in the responsibility array.
 	int myPlace;
 	/// The keys determined by the Sorter that separate me from my
@@ -2055,8 +2052,6 @@ bool bIsReplica(int reqID);
 void printGenericTree(GenericTreeNode* node, std::ostream& os) ;
 //bool compBucket(GenericTreeNode *ln,GenericTreeNode *rn);
 
-#ifdef REDUCTION_HELPER
-
 class TreePieceCounter : public CkLocIterator { 
   public:
     TreePieceCounter() { reset(); }
@@ -2091,7 +2086,7 @@ class ReductionHelper : public CBase_ReductionHelper {
   TreePieceCounter localTreePieces;
   std::vector<SFC::Key> splitters;
 };
-#endif
+
 
 /// @brief Used to count non-empty treepieces on the local processor.
 class NonEmptyTreePieceCounter : public CkLocIterator {            

--- a/Sorter.cpp
+++ b/Sorter.cpp
@@ -275,13 +275,9 @@ void Sorter::startSorting(const CkGroupID& dataManagerID,
   Key k;
   BinaryTreeNode *rt;
 
-#ifdef REDUCTION_HELPER
   // The reduction helper needs to know the number of pieces on each processor.
   reductionHelperProxy.countTreePieces(CkCallbackResumeThread());
   CProxy_ReductionHelper boundariesTargetProxy = reductionHelperProxy; 
-#else
-  CProxy_TreePiece boundariesTargetProxy = treeProxy; 
-#endif
 
   decompTime = CmiWallTimer();
     
@@ -542,12 +538,9 @@ void Sorter::collectEvaluationsOct(CkReductionMsg* m) {
     int arraySize = (1<<refineLevel)+1;
     startTimer = CmiWallTimer();
     Key *array = convertNodesToSplittersRefine(nodesOpened.size(),nodesOpened.getVec());
+
     //CkPrintf("convertNodesToSplittersRefine elts %d took %g s\n", nodesOpened.size()*arraySize, CmiWallTimer()-startTimer);
-#ifdef REDUCTION_HELPER
     CProxy_ReductionHelper boundariesTargetProxy = reductionHelperProxy; 
-#else
-    CProxy_TreePiece boundariesTargetProxy = treeProxy; 
-#endif
     boundariesTargetProxy.evaluateBoundaries(array, nodesOpened.size()*arraySize, 1<<refineLevel, CkCallback(CkIndex_Sorter::collectEvaluations(0), thishandle));
     delete[] array;
   }
@@ -883,13 +876,8 @@ void Sorter::collectEvaluationsSFC(CkReductionMsg* m) {
 
 	} else {
           //send out the new guesses to be evaluated
-#ifdef REDUCTION_HELPER
           CProxy_ReductionHelper boundariesTargetProxy = reductionHelperProxy;
           boundariesTargetProxy.evaluateBoundaries(binsToSplit, CkCallback(CkIndex_Sorter::collectEvaluations(0), thishandle));
-#else
-          CProxy_TreePiece boundariesTargetProxy = treeProxy;
-          boundariesTargetProxy.evaluateBoundaries(&splitters[0], splitters.size(), 0, CkCallback(CkIndex_Sorter::collectEvaluations(0), thishandle));
-#endif
         }
 
 }

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -532,7 +532,6 @@ void TreePiece::evaluateParticleCounts(ORBSplittersMsg *splittersMsg)
   delete splittersMsg;
 }
 
-#ifdef REDUCTION_HELPER
 void ReductionHelper::evaluateBoundaries(SFC::Key* keys, const int n, int skipEvery, const CkCallback& cb){
   splitters.assign(keys, keys + n);
   if(localTreePieces.presentTreePieces.size() == 0){
@@ -578,7 +577,6 @@ void ReductionHelper::evaluateBoundaries(const CkBitVector &binsToSplit, const C
   evaluateBoundaries(&newSplitters[0], newSplitters.size(), 0, cb);
 }
 
-#endif
 
 /// Determine my part of the sorting histograms by counting the number
 /// of my particles in each bin.
@@ -597,16 +595,7 @@ void TreePiece::evaluateBoundaries(SFC::Key* keys, const int n, int skipEvery, c
   int numBins = skipEvery ? n - (n-1)/(skipEvery+1) - 1 : n - 1;
 
   //this array will contain the number of particles I own in each bin
-  int64_t *myCounts;
-
-#ifdef REDUCTION_HELPER
-  myCounts = new int64_t[numBins];
-#else
-  //myBinCounts.assign(numBins, 0);
-  myBinCounts.resize(numBins);
-  myCounts = myBinCounts.getVec();
-#endif
-
+  int64_t *myCounts = new int64_t[numBins];
   memset(myCounts, 0, numBins*sizeof(int64_t));
 
   if (myNumParticles > 0) {
@@ -686,12 +675,8 @@ void TreePiece::evaluateBoundaries(SFC::Key* keys, const int n, int skipEvery, c
   }
   
   //send my bin counts back in a reduction
-#ifdef REDUCTION_HELPER
   reductionHelperProxy.ckLocalBranch()->reduceBinCounts(numBins, myCounts, cb);
   delete[] myCounts;
-#else
-  contribute(numBins * sizeof(int64_t), myCounts, CkReduction::sum_long, cb);
-#endif
 }
 
 void TreePiece::unshuffleParticlesWoDD(const CkCallback& callback) {
@@ -6640,7 +6625,6 @@ void TreePiece::clearMarkedBucketsAll(){
 
 #endif
 
-#ifdef REDUCTION_HELPER
 ReductionHelper::ReductionHelper(){
 }
 
@@ -6704,7 +6688,5 @@ void ReductionHelper::senseLocalTreePieces(){
   CkLocMgr *mgr = treeProxy.ckLocMgr();        
   mgr->iterate(localTreePieces);              
 }
-
-#endif
 
 


### PR DESCRIPTION
This macro is always set in the build system, so having it be configurable is of no use.