### PR TITLE
Remove include of LBDBManager.h since it is gone from charm.

### DIFF
--- a/HierarchOrbLB.cpp
+++ b/HierarchOrbLB.cpp
@@ -6,7 +6,6 @@
 */
 
 #include "HierarchOrbLB.h"
-#include "LBDBManager.h"
 
 #include "GreedyLB.h"
 #include "RefineLB.h"


### PR DESCRIPTION
This fixes a compile error with the latest version of charm.