### PR TITLE
Perform better load balancing after a restart.

### DIFF
--- a/InOutput.cpp
+++ b/InOutput.cpp
@@ -1534,8 +1534,8 @@ void TreePiece::ioShuffle(CkReductionMsg *msg)
     //
     int64_t *startParticle = iOrderBoundaries(numTreePieces, nMaxOrder);
 
-  double tpLoad = getObjTime();
-  populateSavedPhaseData(prevLARung, tpLoad, nPrevActiveParts);
+    double tpLoad = getObjTime();
+    populateSavedPhaseData(iPrevRungLB, tpLoad, nPrevActiveParts);
 
     if (myNumParticles > 0) {
 	// Particles have been sorted in reOrder()

--- a/InOutput.cpp
+++ b/InOutput.cpp
@@ -1535,7 +1535,7 @@ void TreePiece::ioShuffle(CkReductionMsg *msg)
     int64_t *startParticle = iOrderBoundaries(numTreePieces, nMaxOrder);
 
   double tpLoad = getObjTime();
-  populateSavedPhaseData(prevLARung, tpLoad, treePieceActivePartsTmp);
+  populateSavedPhaseData(prevLARung, tpLoad, nPrevActiveParts);
 
     if (myNumParticles > 0) {
 	// Particles have been sorted in reOrder()
@@ -1558,7 +1558,7 @@ void TreePiece::ioShuffle(CkReductionMsg *msg)
 		}
 	    ParticleShuffleMsg *shuffleMsg
 		= new (saved_phase_len, saved_phase_len, nPartOut, nGasOut, nStarOut)
-		ParticleShuffleMsg(saved_phase_len, nPartOut, nGasOut, nStarOut, 0.0);
+		ParticleShuffleMsg(saved_phase_len, nPartOut, nGasOut, nStarOut);
     memset(shuffleMsg->parts_per_phase, 0, saved_phase_len*sizeof(unsigned int));
 	    int iGasOut = 0;
 	    int iStarOut = 0;
@@ -1586,7 +1586,6 @@ void TreePiece::ioShuffle(CkReductionMsg *msg)
            && (pPart->isGas() || pPart->isStar()))
             shuffleMsg->parts_per_phase[PHASE_FEEDBACK] += 1;
 		}
-      shuffleMsg->load = tpLoad * nPartOut / myNumParticles;
       memset(shuffleMsg->loads, 0.0, saved_phase_len*sizeof(double));
 
       // Calculate the partial load per phase
@@ -1631,9 +1630,8 @@ void TreePiece::ioAcceptSortedParticles(ParticleShuffleMsg *shuffleMsg) {
     if(shuffleMsg != NULL) {
 	incomingParticlesMsg.push_back(shuffleMsg);
 	incomingParticlesArrived += shuffleMsg->n;
-  treePieceLoadTmp += shuffleMsg->load;
-  savePhaseData(savedPhaseLoadTmp, savedPhaseParticleTmp, shuffleMsg->loads,
-      shuffleMsg->parts_per_phase, shuffleMsg->nloads);
+        savePhaseData(savedPhaseLoadTmp, savedPhaseParticleTmp, shuffleMsg->loads,
+            shuffleMsg->parts_per_phase, shuffleMsg->nloads);
 	}
 
     if(verbosity > 2)
@@ -1644,9 +1642,6 @@ void TreePiece::ioAcceptSortedParticles(ParticleShuffleMsg *shuffleMsg) {
       //I've got all my particles, now count them
     if(verbosity>1) ckout << thisIndex <<" got ioParticles"
 			  <<endl;
-
-    treePieceLoad = treePieceLoadTmp;
-    treePieceLoadTmp = 0.0;
 
     savedPhaseLoad.swap(savedPhaseLoadTmp);
     savedPhaseParticle.swap(savedPhaseParticleTmp);

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -267,9 +267,8 @@ mainmodule ParallelGravity {
     entry void nextBucketSmooth(dummyMsg *msg);
     entry void nextBucketReSmooth(dummyMsg *msg);
     entry void nextBucketMarkSmooth(dummyMsg *msg);
-    //entry void registerWithDataManager(const CkGroupID& dataManagerID,
-    //		     		  const CkCallback& cb);
 
+    entry void resetObjectLoad(const CkCallback& cb);
     entry void setPeriodic(int nReplicas, Vector3D<cosmoType> fPeriod, int bEwald,
                            double fEwCut, double fEwhCut, int bPeriod,
                            int bComove, double dRhoFac);

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2614,13 +2614,11 @@ Main::restart(CkCheckpointStatusMsg *msg)
 	}
 	
 	dMProxy.resetReadOnly(param, CkCallbackResumeThread());
-  if (bUseCkLoopPar) {
-    CkPrintf("Using CkLoop %d\n", param.bUseCkLoopPar);
-  } else {
-    CkPrintf("Not Using CkLoop %d\n", param.bUseCkLoopPar);
-  }
-  treeProxy.drift(0.0, 0, 0, 0.0, 0.0, 0, true, param.dMaxEnergy,
-                  CkCallbackResumeThread());
+        if (bUseCkLoopPar) {
+            CkPrintf("Using CkLoop %d\n", param.bUseCkLoopPar);
+        } else {
+            CkPrintf("Not Using CkLoop %d\n", param.bUseCkLoopPar);
+        }
 	if(param.bGasCooling || param.bStarForm) 
 	    initCooling();
 	if(param.bStarForm)
@@ -2631,13 +2629,7 @@ Main::restart(CkCheckpointStatusMsg *msg)
         timings.resize(PHASE_FEEDBACK+1);
         nActiveGrav = nTotalParticles;
         nActiveSPH = nTotalSPH;
-
-        /***** Initial sorting of particles and Domain Decomposition *****/
-        CkPrintf("Initial ");
-        domainDecomp(0);
-
-        // Balance load initially after decomposition
-        loadBalance(-1);
+        treeProxy.resetObjectLoad(CkCallbackResumeThread());
 
         doSimulation();
 	}

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2619,6 +2619,8 @@ Main::restart(CkCheckpointStatusMsg *msg)
         } else {
             CkPrintf("Not Using CkLoop %d\n", param.bUseCkLoopPar);
         }
+        treeProxy.drift(0.0, 0, 0, 0.0, 0.0, 0, true, param.dMaxEnergy,
+                        CkCallbackResumeThread());
 	if(param.bGasCooling || param.bStarForm) 
 	    initCooling();
 	if(param.bStarForm)
@@ -2630,6 +2632,9 @@ Main::restart(CkCheckpointStatusMsg *msg)
         nActiveGrav = nTotalParticles;
         nActiveSPH = nTotalSPH;
         treeProxy.resetObjectLoad(CkCallbackResumeThread());
+        /***** Initial sorting of particles and Domain Decomposition *****/
+        CkPrintf("Initial ");
+        domainDecomp(0);
 
         doSimulation();
 	}

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -297,14 +297,13 @@ public:
     int n;
     int nSPH;
     int nStar;
-    double load;
     double *loads;
     unsigned int *parts_per_phase;
     GravityParticle *particles;
     extraSPHData *pGas;
     extraStarData *pStar;
-    ParticleShuffleMsg(int nload, int npart, int nsph, int nstar, double pload): 
-      nloads(nload), n(npart), nSPH(nsph), nStar(nstar), load(pload) {}
+    ParticleShuffleMsg(int nload, int npart, int nsph, int nstar): 
+      nloads(nload), n(npart), nSPH(nsph), nStar(nstar) {}
 };
 
 #ifdef PUSH_GRAVITY
@@ -765,13 +764,13 @@ class TreePiece : public CBase_TreePiece {
 		       // know when writebacks complete.  XXX this
 		       // should be part of the smooth state
    
-   double treePieceLoad; // used to store CPU load data for incoming particles
-   double treePieceLoadTmp; // temporary accumulator for above
-   double treePieceLoadExp;
-   unsigned int treePieceActivePartsTmp;
+   /// number of active particles on the last active rung for load balancing
+   unsigned int nPrevActiveParts;
    std::vector<double> savedPhaseLoad;
    std::vector<unsigned int> savedPhaseParticle;
+   /// temporary accumulator for phase load information during domain decomposition
    std::vector<double> savedPhaseLoadTmp;
+   /// temporary accumulator for phase particle counts during domain decomposition
    std::vector<unsigned int> savedPhaseParticleTmp;
 
    int memWithCache, memPostCache;  // store memory usage.
@@ -1401,10 +1400,8 @@ private:
 public:
  TreePiece() : pieces(thisArrayID), root(0),
             prevLARung (-1), sTopDown(0), sGravity(0),
-	  sPrefetch(0), sLocal(0), sRemote(0), sPref(0), sSmooth(0), 
-	  treePieceLoad(0.0), treePieceLoadTmp(0.0), treePieceLoadExp(0.0),
-    treePieceActivePartsTmp(0) {
-	  //CkPrintf("[%d] TreePiece created on proc %d\n",thisIndex, CkMyPe());
+            sPrefetch(0), sLocal(0), sRemote(0), sPref(0), sSmooth(0), 
+            nPrevActiveParts(0) {
 	  dm = NULL;
 	  foundLB = Null; 
 	  iterationNo=0;
@@ -1486,7 +1483,6 @@ public:
 	}
 
     TreePiece(CkMigrateMessage* m): pieces(thisArrayID) {
-	  treePieceLoadTmp = 0.0;
 
 	  usesAtSync = true;
 	  //localCache = NULL;
@@ -1659,11 +1655,9 @@ public:
 	// move particles around for output
 	void ioShuffle(CkReductionMsg *msg);
 	void ioAcceptSortedParticles(ParticleShuffleMsg *);
-	/** Inform the DataManager of my node that I'm here.
-	 The callback will receive a CkReductionMsg containing no data.
-	void registerWithDataManager(const CkGroupID& dataManagerID,
-				     const CkCallback& cb);
-	 */
+        /// @brief Set the load balancing data after a restart from
+        /// checkpoint.
+        void resetObjectLoad(const CkCallback& cb);
 	// Assign keys after loading tipsy file and finding Bounding box
 	void assignKeys(CkReductionMsg* m);
 	void evaluateBoundaries(SFC::Key* keys, const int n, int isRefine, const CkCallback& cb);

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1043,9 +1043,10 @@ private:
         LBStrategy foundLB;
         // jetley - saved first internal node
         Vector3D<float> savedCentroid;
-        // jetley - multistep load balancing
-        int prevLARung;
-        int lbActiveRung;
+        /// The phase for which we have just collected load balancing data.
+        int iPrevRungLB;
+        /// The phase for which we are about to do load balancing
+        int iActiveRungLB;
 
 	/// @brief Used to inform the mainchare that the requested operation has
 	/// globally finished
@@ -1399,7 +1400,7 @@ private:
 
 public:
  TreePiece() : pieces(thisArrayID), root(0),
-            prevLARung (-1), sTopDown(0), sGravity(0),
+            iPrevRungLB (-1), sTopDown(0), sGravity(0),
             sPrefetch(0), sLocal(0), sRemote(0), sPref(0), sSmooth(0), 
             nPrevActiveParts(0) {
 	  dm = NULL;

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -5332,7 +5332,9 @@ void TreePiece::setTreePieceLoad(int activeRung) {
 
         dLoadExp  = ratio * savedPhaseLoad[0];
     } else {
-        CkAssert(0);
+	// We have no load data because we have no particles.
+        CkAssert(myNumParticles == 0);
+        dLoadExp = 0.0;
     }
     setObjTime(dLoadExp);
 }


### PR DESCRIPTION
Reset the charm timings after a restart, and do not do a domain
decomposition/load balance before entering doSimulation().
Also a code cleanup/documentation of the multi-phase load
infrastructure.