### PR TITLE
For H2 cooling, read in LW array files when restarting from an output.

### DIFF
--- a/Sph.cpp
+++ b/Sph.cpp
@@ -500,6 +500,18 @@ Main::restartGas()
               }
           else
               CkError("WARNING: no CoolArray3 file, or wrong format for restart\n");
+#ifdef COOLING_MOLECULARH
+          nGas = ncGetCount(basefilename + "/gas/lw");
+          if(nGas == nTotalSPH) {
+              LWOutputParams pLWOut(basefilename, 6, 0.0);
+              treeProxy.readFloatBinary(pLWOut, param.bParaRead,
+                                        CkCallbackResumeThread());
+              bFoundCoolArray = true;
+          }
+          else {
+            CkError("WARNING: no Lyman Werner file for restart\n");
+          }
+#endif
         double dTuFac = param.dGasConst/(param.dConstGamma-1)
                 /param.dMeanMolWeight;
         if(bFoundCoolArray) {
@@ -619,6 +631,16 @@ Main::restartGas()
         else {
             CkError("WARNING: no CoolArray3 file for restart\n");
             }
+#ifdef COOLING_MOLECULARH
+        if(arrayFileExists(basefilename + ".lw", nTotalParticles)) {
+            LWOutputParams pLWOut(basefilename, 0, 0.0);
+            treeProxy.readTipsyArray(pLWOut, CkCallbackResumeThread());
+            bFoundCoolArray = true;
+        }
+        else {
+            CkError("WARNING: no Lyman Werner file for restart\n");
+        }
+#endif
         double dTuFac = param.dGasConst/(param.dConstGamma-1)
                 /param.dMeanMolWeight;
         if(bFoundCoolArray) {

--- a/feedback.cpp
+++ b/feedback.cpp
@@ -381,9 +381,20 @@ void TreePiece::Feedback(const Fdbk &fb, double dTime, double dDelta, const CkCa
 
     /* loop through particles */
     for(unsigned int i = 1; i <= myNumParticles; ++i) {
-	GravityParticle *p = &myParticles[i];
-	if(p->isStar() && p->fTimeForm() >= 0.0) 
-	  fb.DoFeedback(p, dTime, dDeltaYr, fbTotals);
+        GravityParticle *p = &myParticles[i];
+        if(p->isStar()) {
+            if(p->fTimeForm() >= 0.0) {
+                fb.DoFeedback(p, dTime, dDeltaYr, fbTotals);
+            }
+            else {  // zero out feedback quantities for Sinks
+                p->fMSN() = 0.0;
+                p->fSNMetals() = 0.0;
+                p->fMIronOut() = 0.0;
+                p->fMOxygenOut() = 0.0;
+                p->fStarESNrate() = 0.0;
+                p->fNSN() = 0.0;
+            }
+        }
 	else if(p->isGas()){
 	  CkAssert(p->u() >= 0.0);
 	  CkAssert(p->uPred() >= 0.0);
@@ -829,8 +840,8 @@ void DistStellarFeedbackSmoothParams::fcnSmooth(GravityParticle *p,int nSmooth, 
     double dAge, aFac, dCosmoDenFac;
     int i,counter,imind;
     
-    if ( p->fMSN() == 0.0 ){return;}
     if ( p->fTimeForm() < 0.0) {return;}  //don't want to do this calculatino for a BH
+    if ( p->fMSN() == 0.0 ){return;}
  
     /* "Simple" ejecta distribution (see function above) */
     DistFBMME(p,nSmooth,nList);


### PR DESCRIPTION
This fixes issues with uninitialized LW fluxes.