### PR TITLE
Remove dependence on RefineLB

### DIFF
--- a/HierarchOrbLB.cpp
+++ b/HierarchOrbLB.cpp
@@ -5,10 +5,10 @@
  * OrbLB_notopo.
 */
 
+#include "Refiner.h"
+
 #include "HierarchOrbLB.h"
 
-#include "GreedyLB.h"
-#include "RefineLB.h"
 #include "Orb3dLB_notopo.h"
 
 #define  DEBUGF(x)      // CmiPrintf x;
@@ -30,7 +30,6 @@ HierarchOrbLB::HierarchOrbLB(const CkLBOptions &opt): CBase_HierarchOrbLB(opt) {
   // decide which load balancer to call
   // IMPORTANT: currently, the greedy LB must allow objects that
   // are not from existing processors.
-  refinelb = (CentralLB *)AllocateRefineLB();
   orblb = (CentralLB *)AllocateOrb3dLB_notopo();
 
   initTree();
@@ -39,7 +38,6 @@ HierarchOrbLB::HierarchOrbLB(const CkLBOptions &opt): CBase_HierarchOrbLB(opt) {
 
 HierarchOrbLB::~HierarchOrbLB() {
   delete orblb;
-  delete refinelb;
 }
 
 void HierarchOrbLB::GetObjsToMigrate(int toPe, double load, LDStats *stats,
@@ -78,6 +76,53 @@ CLBStatsMsg* HierarchOrbLB::AssembleStats()
 #endif
 }
 
+
+void HierarchOrbLB::refine(LDStats* stats)
+{
+  int obj;
+  int n_pes = stats->nprocs();
+
+  // get original object mapping
+  int* from_procs = Refiner::AllocProcs(n_pes, stats);
+  for(obj=0;obj<stats->n_objs;obj++)  {
+    int pe = stats->from_proc[obj];
+    from_procs[obj] = pe;
+  }
+
+  // Get a new buffer to refine into
+  int* to_procs = Refiner::AllocProcs(n_pes, stats);
+
+  Refiner refiner(1.05);  // overload tolerance=1.05
+
+  refiner.Refine(n_pes, stats, from_procs, to_procs);
+
+  // Save output
+  for(obj=0;obj<stats->n_objs;obj++) {
+      int pe = stats->from_proc[obj];
+      if (to_procs[obj] != pe) {
+        if (_lb_args.debug()>=2)  {
+	  CkPrintf("[%d] Obj %d migrating from %d to %d\n",
+		 CkMyPe(),obj,pe,to_procs[obj]);
+        }
+	stats->to_proc[obj] = to_procs[obj];
+      }
+  }
+
+  if (_lb_args.metaLbOn()) {
+    stats->is_prev_lb_refine = 1;
+    stats->after_lb_avg = refiner.computeAverageLoad();
+    stats->after_lb_max = refiner.computeMax();
+
+    if (_lb_args.debug() > 0)
+      CkPrintf("RefineLB> Max load %lf Avg load %lf\n", stats->after_lb_max,
+          stats->after_lb_avg);
+  }
+
+  // Free the refine buffers
+  Refiner::FreeProcs(from_procs);
+  Refiner::FreeProcs(to_procs);
+}
+
 void HierarchOrbLB::work(LDStats* stats) {
 #if CMK_LBDB_ON
   LevelData *lData = levelData[currentLevel];
@@ -86,7 +131,7 @@ void HierarchOrbLB::work(LDStats* stats) {
     orblb->work(stats);
   }
   else
-    refinelb->work(stats);
+    refine(stats);
 #endif
 }
 

--- a/HierarchOrbLB.h
+++ b/HierarchOrbLB.h
@@ -21,7 +21,6 @@ public:
 
 protected:
   CentralLB *orblb;
-  CentralLB *refinelb;
 
   void init();
   virtual bool QueryBalanceNow(int step) {
@@ -36,7 +35,7 @@ protected:
 
 private:
   CProxy_HierarchOrbLB  thisProxy;
-
+  void refine(LDStats* stats);
 };
 
 #endif /* HIERARCH_ORBLB_H */

--- a/Makefile.in
+++ b/Makefile.in
@@ -114,7 +114,7 @@ threadsafe_ht_path  := $(cache_lib_path)/threadsafe_hashtable
 changa_modules := $(strip MultistepLB MultistepLB_notopo \
                     MultistepNodeLB_notopo Orb3dLB Orb3dLB_notopo HierarchOrbLB)
 
-charm_modules := $(strip CkCache CkIO CkMulticast \
+charm_modules := $(strip CkCache CkIO CkMulticast TreeLB \
                    liveViz CkLoop)
 
 # ------- Helper Variables ----------------------------------------------------

--- a/Makefile.in
+++ b/Makefile.in
@@ -114,8 +114,8 @@ threadsafe_ht_path  := $(cache_lib_path)/threadsafe_hashtable
 changa_modules := $(strip MultistepLB MultistepLB_notopo \
                     MultistepNodeLB_notopo Orb3dLB Orb3dLB_notopo HierarchOrbLB)
 
-charm_modules := $(strip CkCache CkIO CkMulticast RefineLB \
-                   GreedyLB RotateLB liveViz CkLoop)
+charm_modules := $(strip CkCache CkIO CkMulticast \
+                   liveViz CkLoop)
 
 # ------- Helper Variables ----------------------------------------------------
 defines := $(strip @HEXADECAPOLE@ @FLAG_RTFORCE@ @FLAG_ARCH@  \

--- a/Makefile.in
+++ b/Makefile.in
@@ -114,8 +114,8 @@ threadsafe_ht_path  := $(cache_lib_path)/threadsafe_hashtable
 changa_modules := $(strip MultistepLB MultistepLB_notopo \
                     MultistepNodeLB_notopo Orb3dLB Orb3dLB_notopo HierarchOrbLB)
 
-charm_modules := $(strip CkCache CkIO CkMulticast TreeLB \
-                   liveViz CkLoop)
+charm_modules := $(strip CkCache CkIO CkMulticast RefineLB \
+                   GreedyLB RotateLB liveViz CkLoop)
 
 # ------- Helper Variables ----------------------------------------------------
 defines := $(strip @HEXADECAPOLE@ @FLAG_RTFORCE@ @FLAG_ARCH@  \


### PR DESCRIPTION
The Charm++ LB refactor has removed the CentralLB version of RefineLB,
this change removes ChaNGa's dependence on it by implementing RefineLB
directly in HierarchOrbLB. This is a stopgap change, eventually
HierarchOrbLB (and the other ChaNGa load balancers) will be rewritten
to use Charm++'s new TreeLB structure, which should make this code
considerably cleaner and more performant.