### PR TITLE
Unify host pinned memory allocation with hapiMallocHost

### DIFF
--- a/Compute.cpp
+++ b/Compute.cpp
@@ -1055,7 +1055,7 @@ CudaRequest *GenericList<T>::serialize(TreePiece *tp){
     int *affectedBuckets = NULL;
 
     if(totalNumInteractions > 0){
-#ifdef HAPI_USE_CUDAMALLOCHOST
+#ifdef PINNED_HOST_MEMORY
       allocatePinnedHostMemory((void **)&flatlists, totalNumInteractions*sizeof(T));
       allocatePinnedHostMemory((void **)&markers, (numFilledBuckets+1)*sizeof(int));
       allocatePinnedHostMemory((void **)&starts, (numFilledBuckets)*sizeof(int));
@@ -1147,7 +1147,7 @@ CudaRequest *GenericList<ILPart>::serialize(TreePiece *tp){
     int *affectedBuckets = NULL;
 
     if(totalNumInteractions > 0){
-#ifdef HAPI_USE_CUDAMALLOCHOST
+#ifdef PINNED_HOST_MEMORY
       allocatePinnedHostMemory((void **)&flatlists, numParticleInteractions*sizeof(ILCell));
       allocatePinnedHostMemory((void **)&markers, (numFilledBuckets+1)*sizeof(int));
       allocatePinnedHostMemory((void **)&starts, (numFilledBuckets)*sizeof(int));
@@ -1456,7 +1456,7 @@ void ListCompute::sendLocalTreeWalkTriggerToGpu(State *state, TreePiece *tp,
   int *dummySizes = NULL;
 
   // XXX I think this can be deleted --trq.
-#ifdef HAPI_USE_CUDAMALLOCHOST
+#ifdef PINNED_HOST_MEMORY
   allocatePinnedHostMemory((void **)&dummyFlatlists, dummyTotalNumInteractions *
                                                     sizeof(ILCell));
   allocatePinnedHostMemory((void **)&dummyNodeMarkers, (numFilledBuckets+1) *

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -1075,7 +1075,7 @@ void DataManager::transferParticleVarsBack(){
     VariablePartData *buf;
     
     if(savedNumTotalParticles > 0){
-#ifdef HAPI_USE_CUDAMALLOCHOST
+#ifdef PINNED_HOST_MEMORY
       allocatePinnedHostMemory((void **)&buf, savedNumTotalParticles*sizeof(VariablePartData));
 #else
       buf = (VariablePartData *) malloc(savedNumTotalParticles*sizeof(VariablePartData));
@@ -1154,7 +1154,7 @@ void DataManager::updateParticlesFreeMemory(UpdateParticlesStruct *data)
         treePiecesParticlesUpdated = 0;
 
         if(data->size > 0){
-#ifdef HAPI_USE_CUDAMALLOCHOST
+#ifdef PINNED_HOST_MEMORY
             freePinnedHostMemory(data->buf);
 #else
             free(data->buf);

--- a/HostCUDA.cu
+++ b/HostCUDA.cu
@@ -75,7 +75,7 @@ void allocatePinnedHostMemory(void **ptr, size_t size){
     assert(0);
     return;
   }
-  hapiHostMalloc(ptr, size);
+  hapiMallocHost(ptr, size);
 #ifdef CUDA_PRINT_ERRORS
   printf("allocatePinnedHostMemory: %s size: %zu\n", cudaGetErrorString( cudaGetLastError() ), size);
 #endif
@@ -89,7 +89,7 @@ void freePinnedHostMemory(void *ptr){
     assert(0);
     return;
   }
-  hapiHostFree(ptr);
+  hapiFreeHost(ptr);
 #ifdef CUDA_PRINT_ERRORS
   printf("freePinnedHostMemory: %s\n", cudaGetErrorString( cudaGetLastError() ));
 #endif
@@ -735,7 +735,7 @@ void TreePiecePartListDataTransferLocalSmallPhase(CudaRequest *data, CompactPart
 #endif
 
         if(transfer){
-          hapiHostMalloc(bufferHostBuffer, size);
+          hapiMallocHost(bufferHostBuffer, size);
 #ifdef CUDA_PRINT_ERRORS
           printf("TPPartSmallPhase 0: %s\n", cudaGetErrorString( cudaGetLastError() ) );
 #endif

--- a/HostCUDA.cu
+++ b/HostCUDA.cu
@@ -75,11 +75,7 @@ void allocatePinnedHostMemory(void **ptr, size_t size){
     assert(0);
     return;
   }
-#ifdef HAPI_MEMPOOL
-  *ptr = hapiPoolMalloc(size);
-#else
-  cudaMallocHost(ptr, size);
-#endif
+  hapiHostMalloc(ptr, size);
 #ifdef CUDA_PRINT_ERRORS
   printf("allocatePinnedHostMemory: %s size: %zu\n", cudaGetErrorString( cudaGetLastError() ), size);
 #endif
@@ -739,7 +735,7 @@ void TreePiecePartListDataTransferLocalSmallPhase(CudaRequest *data, CompactPart
 #endif
 
         if(transfer){
-          CUDA_MALLOC(bufferHostBuffer, size);
+          hapiHostMalloc(bufferHostBuffer, size);
 #ifdef CUDA_PRINT_ERRORS
           printf("TPPartSmallPhase 0: %s\n", cudaGetErrorString( cudaGetLastError() ) );
 #endif

--- a/HostCUDA.cu
+++ b/HostCUDA.cu
@@ -75,7 +75,11 @@ void allocatePinnedHostMemory(void **ptr, size_t size){
     assert(0);
     return;
   }
-  hapiMallocHost(ptr, size);
+#ifdef HAPI_MEMPOOL
+  hapiMallocHost(ptr, size, true);
+#else
+  hapiMallocHost(ptr, size, false);
+#endif
 #ifdef CUDA_PRINT_ERRORS
   printf("allocatePinnedHostMemory: %s size: %zu\n", cudaGetErrorString( cudaGetLastError() ), size);
 #endif
@@ -89,7 +93,11 @@ void freePinnedHostMemory(void *ptr){
     assert(0);
     return;
   }
-  hapiFreeHost(ptr);
+#ifdef HAPI_MEMPOOL
+  hapiFreeHost(ptr, true);
+#else
+  hapiFreeHost(ptr, false);
+#endif
 #ifdef CUDA_PRINT_ERRORS
   printf("freePinnedHostMemory: %s\n", cudaGetErrorString( cudaGetLastError() ));
 #endif
@@ -735,7 +743,7 @@ void TreePiecePartListDataTransferLocalSmallPhase(CudaRequest *data, CompactPart
 #endif
 
         if(transfer){
-          hapiMallocHost(bufferHostBuffer, size);
+          allocatePinnedHostMemory(bufferHostBuffer, size);
 #ifdef CUDA_PRINT_ERRORS
           printf("TPPartSmallPhase 0: %s\n", cudaGetErrorString( cudaGetLastError() ) );
 #endif

--- a/HostCUDA.cu
+++ b/HostCUDA.cu
@@ -743,7 +743,7 @@ void TreePiecePartListDataTransferLocalSmallPhase(CudaRequest *data, CompactPart
 #endif
 
         if(transfer){
-          allocatePinnedHostMemory(bufferHostBuffer, size);
+          allocatePinnedHostMemory(&bufferHostBuffer, size);
 #ifdef CUDA_PRINT_ERRORS
           printf("TPPartSmallPhase 0: %s\n", cudaGetErrorString( cudaGetLastError() ) );
 #endif

--- a/HostCUDA.h
+++ b/HostCUDA.h
@@ -5,16 +5,6 @@
 #include <cuda_runtime.h>
 #include "cuda_typedef.h"
 
-#ifdef HAPI_USE_CUDAMALLOCHOST
-# ifdef HAPI_MEMPOOL
-#  define CUDA_MALLOC(ptr,sz) ptr = hapiPoolMalloc(size)
-# else
-#  define CUDA_MALLOC(ptr,sz) cudaMallocHost(&(ptr), size)
-# endif
-#else
-# define CUDA_MALLOC(ptr,sz) ptr = malloc(sz)
-#endif
-
 #define THREADS_PER_BLOCK 128
 
 #ifdef GPU_LOCAL_TREE_WALK

--- a/cuda.mk.in
+++ b/cuda.mk.in
@@ -1,6 +1,6 @@
 # optional CUDA flags: 
 # memory:
-# -DHAPI_USE_CUDAMALLOCHOST
+# -DPINNED_HOST_MEMORY
 # -DHAPI_MEMPOOL
 #
 # verbosity, debugging:
@@ -29,7 +29,7 @@ CUDA_DEBUG   = $(DEBUG)
 CUDA_VERBOSE = $(VERBOSE)
 
 cuda_defines += -DCUDA -DSPCUDA
-cuda_defines += -DHAPI_MEMPOOL -DHAPI_USE_CUDAMALLOCHOST
+cuda_defines += -DHAPI_MEMPOOL -DPINNED_HOST_MEMORY
 cuda_defines += -DCUDA_2D_TB_KERNEL
 #cuda_defines += -DCUDA_2D_FLAT
 


### PR DESCRIPTION
This PR unifies memory allocations for host pinned memory with `hapiMallocHost`, removing `CUDA_MALLOC`.

`hapiMallocHost`'s behavior will depend on the compile-time flags: with the default flags in `cuda.mk.in` (`-DHAPI_MEMPOOL` and `-DHAPI_USE_CUDAMALLOCHOST`) the allocations requests will go to the pinned host memory pool managed by HAPI.

This should be merged after https://github.com/UIUC-PPL/charm/pull/3017 in Charm++.