### PR TITLE
Trq/grackle3: add a CMB temperature floor

### DIFF
--- a/cooling_grackle.c
+++ b/cooling_grackle.c
@@ -89,6 +89,7 @@ void clInitConstants( COOL *cl, double dGmPerCcUnit, double dComovingGmPerCcUnit
     cl->my_units.time_units = dSecUnit;
     cl->my_units.velocity_units = cl->my_units.length_units / cl->my_units.time_units;
     cl->my_units.a_units = 1.0; // units for the expansion factor
+    cl->my_units.a_value = 1.0;
 
     /* Erg per Gm unit is calculated as velocity units^2 */
     cl->dErgPerGmUnit = dErgPerGmUnit; // too useful not to keep

--- a/cooling_grackle.c
+++ b/cooling_grackle.c
@@ -253,7 +253,7 @@ void CoolSetTime( COOL *cl, double dTime, double z ) {
     cl->my_units.a_value = a_value;
     cl->my_units.density_units = cl->dComovingGmPerCcUnit/pow(a_value, 3.0);
     cl->my_units.length_units = cl->dKpcUnit*KPCCM*a_value; // cm
-    cl->my_units.velocity_units = cl->my_units.length_units / cl->my_units.time_units;
+    cl->my_units.velocity_units = cl->dKpcUnit*KPCCM / cl->my_units.time_units;
     if (initialize_chemistry_data(&cl->my_units) == 0) {
         fprintf(stderr, "Grackle Error in initialize_chemistry_data.\n");
         assert(0);

--- a/cooling_grackle.c
+++ b/cooling_grackle.c
@@ -114,6 +114,8 @@ void clInitConstants( COOL *cl, double dGmPerCcUnit, double dComovingGmPerCcUnit
         };
     cl->pgrackle_data->metal_cooling = CoolParam.metal_cooling;          // metal cooling on
     cl->pgrackle_data->UVbackground = CoolParam.UVbackground;           // UV background on
+    // Grackle implements a temperature floor from the CMB.
+    cl->pgrackle_data->cmb_temperature_floor = CoolParam.cmb_temperature_floor;
     strncpy( cl->grackle_data_file, CoolParam.grackle_data_file, MAXPATHLEN ); // Permanent local copy
     cl->pgrackle_data->grackle_data_file = cl->grackle_data_file; // hdf5 cloudy data file (pointer to permanent copy)
     
@@ -483,6 +485,11 @@ void CoolAddParams( COOLPARAM *CoolParam, PRM prm ) {
 	CoolParam->UVbackground = 1;
 	prmAddParam(prm,"UVbackground",paramBool,&CoolParam->UVbackground,sizeof(int),"UVbackground",
 				"on = +UVbackground");
+        CoolParam->cmb_temperature_floor = 1;
+        prmAddParam(prm,"cmb_temperature_floor", paramBool,
+                    &CoolParam->cmb_temperature_floor, sizeof(int),
+                    "grackle cmb_temperature_floor parameter",
+                    "on = +cmb_temperature_floor");
 	CoolParam->bComoving = 1;
 	prmAddParam(prm,"bComoving",paramBool,&CoolParam->bComoving,sizeof(int),"bComoving",
 				"on = +bComoving");

--- a/cooling_grackle.c
+++ b/cooling_grackle.c
@@ -27,8 +27,7 @@
 
 #include "cooling.h"
 
-#define mh     1.67262171e-24   
-#define kboltz 1.3806504e-16
+#include "physconst.h"
 
 COOL *CoolInit( )
     {
@@ -85,8 +84,8 @@ void clInitConstants( COOL *cl, double dGmPerCcUnit, double dComovingGmPerCcUnit
 	grackle_verbose = CoolParam.grackle_verbose;
 
     cl->my_units.comoving_coordinates = CoolParam.bComoving; // 1 if cosmological sim, 0 if not
-    cl->my_units.density_units = dGmPerCcUnit;
-    cl->my_units.length_units = dKpcUnit*3.0857e21; // cm
+    cl->my_units.density_units = dComovingGmPerCcUnit;
+    cl->my_units.length_units = dKpcUnit*KPCCM; // cm
     cl->my_units.time_units = dSecUnit;
     cl->my_units.velocity_units = cl->my_units.length_units / cl->my_units.time_units;
     cl->my_units.a_units = 1.0; // units for the expansion factor
@@ -94,6 +93,7 @@ void clInitConstants( COOL *cl, double dGmPerCcUnit, double dComovingGmPerCcUnit
     /* Erg per Gm unit is calculated as velocity units^2 */
     cl->dErgPerGmUnit = dErgPerGmUnit; // too useful not to keep
     cl->diErgPerGmUnit = 1/dErgPerGmUnit;
+    cl->dKpcUnit = dKpcUnit;
     cl->dSecUnit = dSecUnit;
     cl->dComovingGmPerCcUnit = dComovingGmPerCcUnit;
     cl->dErgPerGmPerSecUnit = dErgPerGmUnit/dSecUnit;
@@ -116,20 +116,12 @@ void clInitConstants( COOL *cl, double dGmPerCcUnit, double dComovingGmPerCcUnit
     strncpy( cl->grackle_data_file, CoolParam.grackle_data_file, MAXPATHLEN ); // Permanent local copy
     cl->pgrackle_data->grackle_data_file = cl->grackle_data_file; // hdf5 cloudy data file (pointer to permanent copy)
     
-        {
-        double initial_redshift = 0.;
-        double a_value = 1. / (1. + initial_redshift);
-
-        // Finally, initialize the chemistry object.
-        cl->my_units.a_value = a_value;
-        if (initialize_chemistry_data(&cl->my_units) == 0) {
-            fprintf(stderr, "Grackle Error in initialize_chemistry_data.\n");
-            assert(0);
-            }
-        }
-
-
+    // Finally, initialize the chemistry object.
+    if (initialize_chemistry_data(&cl->my_units) == 0) {
+	fprintf(stderr, "Grackle Error in initialize_chemistry_data.\n");
+	assert(0);
     }
+}
 
 /*Returns baryonic fraction for a given species*/
 double COOL_ARRAY0(COOL *cl, COOLPARTICLE *cp, double ZMetal) {
@@ -257,15 +249,16 @@ void CoolSetTime( COOL *cl, double dTime, double z ) {
     double a_value = 1. / (1. + z);
 
     cl->dTime = dTime;
-    cl->z = z;
-    cl->a = a_value;
-/*
-    if (initialize_chemistry_data(&cl->my_units, a_value) == 0) {
+    // Update grackle units to current expansion factor.
+    cl->my_units.a_value = a_value;
+    cl->my_units.density_units = cl->dComovingGmPerCcUnit/pow(a_value, 3.0);
+    cl->my_units.length_units = cl->dKpcUnit*KPCCM*a_value; // cm
+    cl->my_units.velocity_units = cl->my_units.length_units / cl->my_units.time_units;
+    if (initialize_chemistry_data(&cl->my_units) == 0) {
         fprintf(stderr, "Grackle Error in initialize_chemistry_data.\n");
         assert(0);
-        }
-*/
     }
+}
 
 
 void CoolDefaultParticleData( COOLPARTICLE *cp ) 
@@ -327,7 +320,7 @@ void CoolInitEnergyAndParticleData( COOL *cl, COOLPARTICLE *cp, double *E, doubl
     // No routine in Grackle to use to set up energy sensibly
     // Energy: erg per gm --> code units   assumes neutral gas (as above)
     // This is not called after checkpoints so should be ok
-    *E = dTemp*(kboltz*1.5/(1.2*mh))*cl->diErgPerGmUnit;
+    *E = dTemp*(KBOLTZ*1.5/(1.2*MHYDR))*cl->diErgPerGmUnit;
 
 //    printf("Grackle %d \n",GRACKLE_PRIMORDIAL_CHEMISTRY_MAX);
 //    printf("%g %g   %g %g %g %g %g %g %g\n",dDensity,*E,cp->HI,cp->HII,cp->HeI,cp->HeII,cp->HeIII,cp->e);

--- a/cooling_grackle.c
+++ b/cooling_grackle.c
@@ -116,6 +116,11 @@ void clInitConstants( COOL *cl, double dGmPerCcUnit, double dComovingGmPerCcUnit
     cl->pgrackle_data->UVbackground = CoolParam.UVbackground;           // UV background on
     // Grackle implements a temperature floor from the CMB.
     cl->pgrackle_data->cmb_temperature_floor = CoolParam.cmb_temperature_floor;
+    cl->bFixTempFloor = 0;
+    if(CoolParam.cmb_temperature_floor && CoolParam.bBrokenGrackleFloor) {
+	cl->pgrackle_data->cmb_temperature_floor = 0;
+	cl->bFixTempFloor = 1;
+    }
     strncpy( cl->grackle_data_file, CoolParam.grackle_data_file, MAXPATHLEN ); // Permanent local copy
     cl->pgrackle_data->grackle_data_file = cl->grackle_data_file; // hdf5 cloudy data file (pointer to permanent copy)
     
@@ -422,8 +427,36 @@ void CoolIntegrateEnergyCode(COOL *cl, clDerivsData *clData, COOLPARTICLE *cp, d
             fprintf(stderr, "Grackle Error in solve_chemistry.\n");
             assert(0);
     }
-    
+
     assert(energy > 0.0);
+    if(cl->bFixTempFloor) {
+        double temperature;
+        if (calculate_temperature(&cl->my_units, &my_fields, &temperature) == 0) {
+            fprintf(stderr, "Grackle Error in calculate_temperature.\n");
+            assert(0);
+        }
+        const double dTCMB0 = 2.725; /* CMB temperature at z = 0 */
+        double dTCMB_z = dTCMB0/cl->my_units.a_value;
+        if(temperature < dTCMB_z) {
+            int itr = 0;
+            const double dTol = 0.99;  /* get floor to this accuracy */
+            do {
+                energy *= dTCMB_z/temperature; /* Assume that energy
+                                                 scales linearly with
+                                                 temperature */
+                if (calculate_temperature(&cl->my_units, &my_fields, &temperature) == 0) {
+                    fprintf(stderr, "Grackle Error in calculate_temperature.\n");
+                    assert(0);
+                }
+                itr++;
+            } while(temperature < dTol*dTCMB_z && itr < 50);
+
+            if(temperature < dTCMB_z*dTol) {
+                fprintf(stderr, "temp: %g, CMB: %g\n", temperature, dTCMB_z);
+            }
+            assert(itr < 50);
+        }
+    }
     *E = energy;
 
 #if (GRACKLE_PRIMORDIAL_CHEMISTRY_MAX>=1)
@@ -488,8 +521,13 @@ void CoolAddParams( COOLPARAM *CoolParam, PRM prm ) {
         CoolParam->cmb_temperature_floor = 1;
         prmAddParam(prm,"cmb_temperature_floor", paramBool,
                     &CoolParam->cmb_temperature_floor, sizeof(int),
-                    "grackle cmb_temperature_floor parameter",
-                    "on = +cmb_temperature_floor");
+                    "grackle_cmb_tfloor",
+                    "grackle cmb_temperature_floor parameter, [on]");
+        CoolParam->bBrokenGrackleFloor = 0;
+        prmAddParam(prm,"bBrokenGrackleFloor", paramBool,
+                    &CoolParam->bBrokenGrackleFloor, sizeof(int),
+                    "broken_grackle_tfloor",
+                    "assume the grackle cmb temperature floor is broken [off]");
 	CoolParam->bComoving = 1;
 	prmAddParam(prm,"bComoving",paramBool,&CoolParam->bComoving,sizeof(int),"bComoving",
 				"on = +bComoving");

--- a/cooling_grackle.h
+++ b/cooling_grackle.h
@@ -62,10 +62,9 @@ typedef struct CoolingParticleStruct {
 
 typedef struct CoolingPKDStruct { 
 // not official grackle stuff    
-    double     z; 
-    double     a;
     double     dTime;
     double     dSecUnit; 
+    double     dKpcUnit; 
     double     dComovingGmPerCcUnit; 
     double     dErgPerGmUnit; 
     double     diErgPerGmUnit;
@@ -257,25 +256,6 @@ double CoolCodePressureOnDensity( COOL *cl, COOLPARTICLE *cp, double uPred, doub
 
 #define CoolCodePressureOnDensity( cl, cp, uPred, fDensity, gammam1 ) ((gammam1)*(uPred))
 */
-
-#if 0
-struct inInitCooling {
-  double dGmPerCcUnit;
-  double dComovingGmPerCcUnit;
-  double dErgPerGmUnit;
-  double dSecUnit;
-  double dKpcUnit;
-  double z;
-  double dTime;
-  COOLPARAM CoolParam;
-};
-
-struct inInitEnergy {
-	double dTuFac;
-	double z;
-	double dTime;
-	};
-#endif
 
 void CoolTableReadInfo( COOLPARAM *CoolParam, int cntTable, int *nTableColumns, char *suffix );
 

--- a/cooling_grackle.h
+++ b/cooling_grackle.h
@@ -37,6 +37,7 @@ typedef struct CoolingParametersStruct {
     int primordial_chemistry; // = 3;   // molecular network with H, He, D
     int metal_cooling; // = 1;          // metal cooling on
     int UVbackground; // = 1;           // UV background on
+    int cmb_temperature_floor; // default 1
 
     int bComoving; // part of units
     char grackle_data_file[MAXPATHLEN]; // "../../input/CloudyData_UVB=HM2012.h5"; // data file

--- a/cooling_grackle.h
+++ b/cooling_grackle.h
@@ -38,6 +38,9 @@ typedef struct CoolingParametersStruct {
     int metal_cooling; // = 1;          // metal cooling on
     int UVbackground; // = 1;           // UV background on
     int cmb_temperature_floor; // default 1
+    int bBrokenGrackleFloor;		// Use external CMB floor
+					// assuming Grackle's CMB
+					// floor is broken.
 
     int bComoving; // part of units
     char grackle_data_file[MAXPATHLEN]; // "../../input/CloudyData_UVB=HM2012.h5"; // data file
@@ -74,6 +77,7 @@ typedef struct CoolingPKDStruct {
     char grackle_data_file[MAXPATHLEN]; // "../../input/CloudyData_UVB=HM2012.h5"; // data file
     chemistry_data *pgrackle_data;  // defined in chemistry_data.h, points at global grackle_data
     code_units my_units;     // defined in code_units.h
+    int bFixTempFloor;	     /* Set CMB temperature floor outside of Grackle */
 #if defined(COOLDEBUG)
     MDL        mdl; /* For diag/debug outputs */
     struct particle *p; /* particle pointer NEVER TO BE USED EXCEPT FOR DEBUG */


### PR DESCRIPTION
The grackle implementation of the CMB temperature floor has some weird effects at high densities, according to other codes in the AGORA collaboration.  Here a separate CMB floor implementation  is added to the cooling_grackle implementation with a parameter to turn it on.