### PR TITLE
Remove check when building with Charm++ CUDA build

### DIFF
--- a/configure
+++ b/configure
@@ -5547,9 +5547,6 @@ esac
 if test x$BUILD_CUDA = x; then
 	BUILD_CUDA=0
 fi
-if test x$ENABLE_CUDA = xno -a x$BUILD_CUDA = x1; then
-	as_fn_error $? "Charm++ ($CHARM_PATH) was built with CUDA support enabled." "$LINENO" 5
-fi
 if test x$ENABLE_CUDA = xyes -a x$BUILD_CUDA = x0; then
 	as_fn_error $? "Charm++ ($CHARM_PATH) was not built with CUDA support." "$LINENO" 5
 fi

--- a/cuda.ac
+++ b/cuda.ac
@@ -36,9 +36,6 @@ esac
 if test x$BUILD_CUDA = x; then
 	BUILD_CUDA=0
 fi
-if test x$ENABLE_CUDA = xno -a x$BUILD_CUDA = x1; then
-	AC_MSG_ERROR([Charm++ ($CHARM_PATH) was built with CUDA support enabled.])
-fi
 if test x$ENABLE_CUDA = xyes -a x$BUILD_CUDA = x0; then
 	AC_MSG_ERROR([Charm++ ($CHARM_PATH) was not built with CUDA support.])
 fi	


### PR DESCRIPTION
Since Charm++ CUDA build can be used with both CUDA and non-CUDA builds of ChaNGa, the check that prevents non-CUDA ChaNGa from being built against Charm++ CUDA build should be disabled.