### PR TITLE
Remove deprecated calls to LBSetPeriod

### DIFF
--- a/DataManager.h
+++ b/DataManager.h
@@ -300,10 +300,20 @@ class ProjectionsControl : public CBase_ProjectionsControl {
   ProjectionsControl() {
     setBIconfig();
     LBTurnCommOff();
+#ifndef LB_MANAGER_VERSION
+    // Older Charm++ requires this to avoid excessive delays between successive LBs even
+    // when using AtSync mode
+    LBSetPeriod(0.0);
+#endif
   } 
   ProjectionsControl(CkMigrateMessage *m) : CBase_ProjectionsControl(m) {
     setBIconfig();
     LBTurnCommOff();
+#ifndef LB_MANAGER_VERSION
+    // Older Charm++ requires this to avoid excessive delays between successive LBs even
+    // when using AtSync mode
+    LBSetPeriod(0.0);
+#endif
   } 
  
   void on(CkCallback cb) { 

--- a/DataManager.h
+++ b/DataManager.h
@@ -300,12 +300,10 @@ class ProjectionsControl : public CBase_ProjectionsControl {
   ProjectionsControl() {
     setBIconfig();
     LBTurnCommOff();
-    LBSetPeriod(0.0); // no need for LB interval: we are using Sync Mode
   } 
   ProjectionsControl(CkMigrateMessage *m) : CBase_ProjectionsControl(m) {
     setBIconfig();
     LBTurnCommOff();
-    LBSetPeriod(0.0); // no need for LB interval: we are using Sync Mode
   } 
  
   void on(CkCallback cb) { 


### PR DESCRIPTION
The new load balancing infrastructure in Charm++ obviates the need to
set the period to something small when using AtSync mode. Futher, it
disallows setting an LB period at all when using AtSync mode.