### PR TITLE
updateuDot(): handle superbubble feedback in slow particles.

### DIFF
--- a/Sph.cpp
+++ b/Sph.cpp
@@ -914,10 +914,15 @@ void TreePiece::updateuDot(int activeRung,
                 p->uHotDot() = (E- p->uHot())/duDelta[p->rung];
                 if(bUpdateState) p->CoolParticleHot() = cp;
             }
-            else /* If we just got feedback, only set up the uDot */
-            {
+            else if(p->cpHotInit() == 0) {
+                /* If we just got feedback, only set up the uDot */
+                /* If cpHotInit is still 1 at this point, we have recently
+                 * gotten feedback, but the particle (presumably on a long
+                 * timestep has yet to do a updateuDot() with it.  Leave
+                 * uDotHot() at its current value in this case. */
                 p->uHotDot() = ExternalHeating;
                 p->cpHotInit() = 1;
+	        assert(ExternalHeating > 0.0);
             }
             ExternalHeating = p->PdV()*p->u()/uMean;
         }

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -1646,6 +1646,7 @@ void TreePiece::kick(int iKickRung, double dDelta[MAXRUNG+1],
 		      p->uHot() = p->uHot() + p->uHotDot()*duDelta[p->rung];
               if (p->cpHotInit()) {
                  double E = p->uHot();
+                 CkAssert(E > 0.0);
                  double frac = p->massHot()/p->mass;
                  double PoverRho = gammam1*(p->uHotPred()*frac+p->uPred()*(1-frac));
                  double fDensity = p->fDensity*PoverRho/(gammam1*p->uHot()); /* Density of bubble part of particle */


### PR DESCRIPTION
I ran into a problem with SUPERBUBBLE creating "hot" gas with infinite densities in TreePiece::updateuDot().
I believe the problem is that if a particle with a timestep as long as or longer than the star formation timestep gets supernova energy, the fSNErate gets reset at the next feedback event BEFORE uHot gets updated.  The solution here is to keep uHotDot() unchanged if cpHotInit is still set.