### PR TITLE
LB: Remove dependency on CkVec from LB interface

### DIFF
--- a/HierarchOrbLB.h
+++ b/HierarchOrbLB.h
@@ -27,10 +27,9 @@ protected:
     if(step == 0) return false;
     return true;
   };
-  virtual bool QueryMigrateStep(int) { return true; };
+  virtual bool
+  QueryMigrateStep(int) { return true; };
   virtual void work(LDStats* stats);
-  virtual void GetObjsToMigrate(int toPe, double load, LDStats *stats,
-      int atlevel, CkVec<LDCommData>& comms, CkVec<LDObjData>& objs);
   virtual CLBStatsMsg* AssembleStats();
 
 private:

--- a/MultistepLB.cpp
+++ b/MultistepLB.cpp
@@ -85,6 +85,7 @@ void MultistepLB::work(BaseLB::LDStats* stats)
 #if CMK_LBDB_ON
   // find active objects - mark the inactive ones as non-migratable
   int count;
+  const auto numObjs = stats->objData.size();
 
   int numActiveObjects = 0;
   int numInactiveObjects = 0;
@@ -93,11 +94,11 @@ void MultistepLB::work(BaseLB::LDStats* stats)
   int64_t numActiveParticles = 0;
   int64_t totalNumParticles = 0;
 
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < numObjs; i++){
     stats->to_proc[i] = stats->from_proc[i];
   }
 
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < numObjs; i++){
     if (!stats->objData[i].migratable) continue;
 
     LDObjData &odata = stats->objData[i];
@@ -128,7 +129,7 @@ void MultistepLB::work(BaseLB::LDStats* stats)
   CkPrintf("**********************************************\n");
   CkPrintf("Object load predictions phase %d\n", phase);
   CkPrintf("**********************************************\n");
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < numObjs; i++){
       int tp = tpCentroids[i].tp;
       int lb = tpCentroids[i].tag;
     CkPrintf("tp %d load %f\n",tp,stats->objData[lb].wallTime);
@@ -167,13 +168,13 @@ void MultistepLB::work(BaseLB::LDStats* stats)
 //
 void MultistepLB::greedy(BaseLB::LDStats *stats, int count){
 
-  int numobjs = stats->n_objs;
+  const int numobjs = stats->objData.size();
   int nmig = stats->n_migrateobjs;
   CkPrintf("[GREEDY] objects total %d active %d\n", numobjs,nmig);
 
   TPObject *tp_array = new TPObject[nmig];
   int j = 0;
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < numobjs; i++){
     if(!stats->objData[i].migratable) continue;
     tp_array[j].migratable = stats->objData[i].migratable;
 
@@ -244,7 +245,7 @@ void MultistepLB::greedy(BaseLB::LDStats *stats, int count){
 }
 
 void MultistepLB::work2(BaseLB::LDStats *stats, int count){
-  int numobjs = stats->n_objs;
+  const int numobjs = stats->objData.size();
   int nmig = stats->n_migrateobjs;
 
   if (_lb_args.debug()>=2) {

--- a/MultistepLB.h
+++ b/MultistepLB.h
@@ -67,7 +67,7 @@ private:
   ComparatorFn compares[NDIMS];
   ComparatorFn pc[NDIMS];
 
-  CkVec<int> *mapping;
+  decltype(LDStats::to_proc) *mapping;
 
   int procsPerNode;
 

--- a/MultistepLB_notopo.cpp
+++ b/MultistepLB_notopo.cpp
@@ -59,6 +59,7 @@ void MultistepLB_notopo::work(BaseLB::LDStats* stats)
 #if CMK_LBDB_ON
   // find active objects - mark the inactive ones as non-migratable
   int count;
+  const auto num_objs = stats->objData.size();
 
   if(_lb_args.debug() >= 2 && step() > 0) {
       // Write out "particle file" of measured load balance information
@@ -66,15 +67,15 @@ void MultistepLB_notopo::work(BaseLB::LDStats* stats)
       FILE *fp = fopen(achFileName.c_str(), "w");
       CkAssert(fp != NULL);
 
-      int num_migratables = stats->n_objs;
-      for(int i = 0; i < stats->n_objs; i++) {
+      int num_migratables = num_objs;
+      for(int i = 0; i < num_objs; i++) {
         if (!stats->objData[i].migratable) {
           num_migratables--;
         }
       }
 
       fprintf(fp, "%d %d 0\n", num_migratables, num_migratables);
-      for(int i = 0; i < stats->n_objs; i++) {
+      for(int i = 0; i < num_objs; i++) {
         if (!stats->objData[i].migratable) continue;
 
       LDObjData &odata = stats->objData[i];
@@ -95,11 +96,11 @@ void MultistepLB_notopo::work(BaseLB::LDStats* stats)
   int minActiveProc = INT_MAX;
   int maxActiveProc = 0;
 
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < num_objs; i++){
     stats->to_proc[i] = stats->from_proc[i];
   }
 
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < num_objs; i++){
     if (!stats->objData[i].migratable) continue;
 
     LDObjData &odata = stats->objData[i];
@@ -121,7 +122,7 @@ void MultistepLB_notopo::work(BaseLB::LDStats* stats)
   CkPrintf("active PROC range: %d to %d\n", minActiveProc, maxActiveProc);
   if(numActiveObjects < 0.1*numInactiveObjects) {
     // only a small number of active objects, only migrate them
-    for(int i = 0; i < stats->n_objs; i++){
+    for(int i = 0; i < stats->objData.size(); i++){
       if (!stats->objData[i].migratable) continue;
 
       LDObjData &odata = stats->objData[i];
@@ -158,7 +159,7 @@ void MultistepLB_notopo::work(BaseLB::LDStats* stats)
 
 /// @brief ORB3D load balance.
 void MultistepLB_notopo::work2(BaseLB::LDStats *stats, int count){
-  int numobjs = stats->n_objs;
+  const int numobjs = stats->objData.size();
   int nmig = stats->n_migrateobjs;
 
   // this data structure is used by the orb3d strategy

--- a/MultistepNodeLB_notopo.cpp
+++ b/MultistepNodeLB_notopo.cpp
@@ -45,22 +45,23 @@ void MultistepNodeLB_notopo::work(BaseLB::LDStats* stats)
 #if CMK_LBDB_ON
   // find active objects - mark the inactive ones as non-migratable
   int count;
-  
+  const auto num_objs = stats->objData.size();
+
   if(_lb_args.debug() >= 2 && step() > 0) {
       // Write out "particle file" of measured load balance information
       auto achFileName = make_formatted_string("lb_a.%d.sim", step()-1);
       FILE *fp = fopen(achFileName.c_str(), "w");
       CkAssert(fp != NULL);
 
-      int num_migratables = stats->n_objs;
-      for(int i = 0; i < stats->n_objs; i++) {
+      int num_migratables = num_objs;
+      for(int i = 0; i < num_objs; i++) {
         if (!stats->objData[i].migratable) {
           num_migratables--;
         }
       }
       fprintf(fp, "%d %d 0\n", num_migratables, num_migratables);
 
-      for(int i = 0; i < stats->n_objs; i++) {
+      for(int i = 0; i < num_objs; i++) {
         if(!stats->objData[i].migratable) continue;
 
       LDObjData &odata = stats->objData[i];
@@ -83,11 +84,11 @@ void MultistepNodeLB_notopo::work(BaseLB::LDStats* stats)
   int numActiveParticles = 0;
   int totalNumParticles = 0;
  
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < num_objs; i++){
     stats->to_proc[i] = stats->from_proc[i];
   }
   
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < num_objs; i++){
     if(!stats->objData[i].migratable) continue;
 
     LDObjData &odata = stats->objData[i];
@@ -114,7 +115,7 @@ void MultistepNodeLB_notopo::work(BaseLB::LDStats* stats)
       numInactiveObjects);
   if(numInactiveObjects < 1.0*numActiveObjects) {
     // insignificant number of inactive objects; migrate them anyway
-    for(int i = 0; i < stats->n_objs; i++){
+    for(int i = 0; i < num_objs; i++){
       if(!stats->objData[i].migratable) continue;
 
       LDObjData &odata = stats->objData[i];
@@ -134,7 +135,7 @@ void MultistepNodeLB_notopo::work(BaseLB::LDStats* stats)
   CkPrintf("**********************************************\n");
   CkPrintf("Object load predictions phase %d\n", phase);
   CkPrintf("**********************************************\n");
-  for(int i = 0; i < stats->n_objs; i++){
+  for(int i = 0; i < num_objs; i++){
       int tp = tpCentroids[i].tp;
       int lb = tpCentroids[i].tag;
     CkPrintf("tp %d load %f\n",tp,stats->objData[lb].wallTime);
@@ -164,7 +165,7 @@ void MultistepNodeLB_notopo::work(BaseLB::LDStats* stats)
 
 /// @brief ORB3D load balance across nodes (as opposed to processors).
 void MultistepNodeLB_notopo::work2(BaseLB::LDStats *stats, int count){
-  int numobjs = stats->n_objs;
+  const int numobjs = stats->objData.size();
   int nmig = stats->n_migrateobjs;
 
   // this data structure is used by the orb3d strategy
@@ -293,7 +294,7 @@ void MultistepNodeLB_notopo::balanceTPsNode(BaseLB::LDStats* stats) {
                                   // each node.
   objpemap.resize(numNodes);
   
-  for (int i = 0; i < stats->n_objs; i++) {
+  for (int i = 0; i < stats->objData.size(); i++) {
     if(!stats->objData[i].migratable) continue;
 
     int nd = stats->to_proc[i]/nodeSize;
@@ -397,7 +398,7 @@ void MultistepNodeLB_notopo::balanceTPs(BaseLB::LDStats* stats) {
   vector<vector<int> > objpemap;
   objpemap.resize(stats->count);
   
-  for (int i = 0; i < stats->n_objs; i++) {
+  for (int i = 0; i < stats->objData.size(); i++) {
     if(!stats->objData[i].migratable) continue;
 
     counts[stats->to_proc[i]] += stats->objData[i].wallTime;

--- a/Orb3dLB.cpp
+++ b/Orb3dLB.cpp
@@ -105,7 +105,7 @@ bool Orb3dLB::QueryBalanceNow(int step){
 
 void Orb3dLB::work(BaseLB::LDStats* stats)
 {
-  int numobjs = stats->n_objs;
+  const int numobjs = stats->objData.size();
 
   CkPrintf("[orb3dlb] %d objects allocating %lu bytes for tp\n", numobjs, numobjs*sizeof(TPObject));
   tps.resize(numobjs);

--- a/Orb3dLB.h
+++ b/Orb3dLB.h
@@ -23,7 +23,7 @@ private:
   ComparatorFn compares[NDIMS];
   ComparatorFn pc[NDIMS];
   // pointer to stats->to_proc
-  CkVec<int> *mapping;
+  decltype(LDStats::to_proc) *mapping;
 
   int procsPerNode;
 

--- a/Orb3dLBCommon.h
+++ b/Orb3dLBCommon.h
@@ -38,8 +38,8 @@ class ProcLdGreater {
 class Orb3dCommon{
   // pointer to stats->to_proc
   protected:		
-    CkVec<int> *mapping;
-    CkVec<int> *from;
+    decltype(BaseLB::LDStats::to_proc) *mapping;
+    decltype(BaseLB::LDStats::from_proc) *from;
 
     CkVec<float> procload;
 

--- a/Orb3dLB_notopo.cpp
+++ b/Orb3dLB_notopo.cpp
@@ -41,7 +41,7 @@ bool Orb3dLB_notopo::QueryBalanceNow(int step){
 
 void Orb3dLB_notopo::work(BaseLB::LDStats* stats)
 {
-  int numobjs = stats->n_objs;
+  const int numobjs = stats->objData.size();
   int nmig = stats->n_migrateobjs;
   double gstarttime = CkWallTimer();
 
@@ -67,7 +67,7 @@ void Orb3dLB_notopo::work(BaseLB::LDStats* stats)
   }
   else{
 
-    for(int i = 0; i < stats->n_objs; i++){
+    for(int i = 0; i < numobjs; i++){
       float load;
       load = stats->objData[i].wallTime;
 
@@ -134,7 +134,7 @@ void Orb3dLB_notopo::work(BaseLB::LDStats* stats)
     for(int i = 0; i < numobjs; i++) {
       if (!stats->objData[i].migratable) continue;
 
-	    CkAssert(tps[i].lbindex < stats->n_objs);
+	    CkAssert(tps[i].lbindex < numobjs);
 	    CkAssert(tps[i].lbindex >= 0);
 	    fprintf(fp, "%g %g %g %g 0.0 0.0 0.0 %d 0.0\n",
 		stats->objData[tps[i].lbindex].wallTime,


### PR DESCRIPTION
I am trying to remove `CkVec` (which was originally used because `std::vector` wasn't available or portable enough) from the Charm++ LB infrastructure. This change makes ChaNGa agnostic to what the underlying data types are in the LB API.