### PR TITLE
LB: Use nprocs() instead of accessing count directly

### DIFF
--- a/MultistepLB.cpp
+++ b/MultistepLB.cpp
@@ -69,7 +69,7 @@ void MultistepLB::makeActiveProcessorList(BaseLB::LDStats *stats, int numActiveO
   int objsPerProc = 8;
   int expandFactor = 4;
   int procsNeeded;
-  procsNeeded = expandFactor*numActiveObjs/objsPerProc > stats->count ? stats->count : expandFactor*numActiveObjs/objsPerProc;
+  procsNeeded = expandFactor*numActiveObjs/objsPerProc > stats->nprocs() ? stats->nprocs() : expandFactor*numActiveObjs/objsPerProc;
 
   /* currently, only the first procsNeeded procs are used - could do something more sophisticated here in the future - FIXME */
 #ifdef MCLBMSV
@@ -145,7 +145,7 @@ void MultistepLB::work(BaseLB::LDStats* stats)
   CkPrintf("making active processor list\n");
 #endif
   makeActiveProcessorList(stats, numActiveObjects);
-  count = stats->count;
+  count = stats->nprocs();
 
   // let the strategy take over on this modified instrumented data and processor information
   if((float)numActiveParticles/totalNumParticles > LARGE_PHASE_THRESHOLD){
@@ -232,7 +232,7 @@ void MultistepLB::greedy(BaseLB::LDStats *stats, int count){
   CkPrintf("**********************************\n");
   CkPrintf("GREEDY MEASURED CPU LOAD\n");
   CkPrintf("**********************************\n");
-  for(int i = 0; i < stats->count; i++){
+  for(int i = 0; i < stats->nprocs(); i++){
     CkPrintf("[pestats] %d %g %g\n",
                                i,
                                stats->procs[i].total_walltime,
@@ -299,7 +299,7 @@ void MultistepLB::work2(BaseLB::LDStats *stats, int count){
   }
   Node *nodes = new Node[numnodes];
 
-  for(int i = 0; i < stats->count; i++){
+  for(int i = 0; i < stats->nprocs(); i++){
     int t;
     int x,y,z;
     int node;
@@ -318,8 +318,8 @@ void MultistepLB::work2(BaseLB::LDStats *stats, int count){
   }
   map(tp_array,nmig,numnodes,nodes,nx,ny,nz,dim);
 
-  float *objload = new float[stats->count];
-  for(int i = 0; i < stats->count; i++){
+  float *objload = new float[stats->nprocs()];
+  for(int i = 0; i < stats->nprocs(); i++){
     objload[i] = 0.0;
   }
   for(j = 0; j < nmig; j++){
@@ -334,7 +334,7 @@ void MultistepLB::work2(BaseLB::LDStats *stats, int count){
   CkPrintf("******************************\n");
   CkPrintf("CPU LOAD PREDICTIONS phase %d\n", phase);
   CkPrintf("******************************\n");
-  for(int i = 0; i < stats->count; i++){
+  for(int i = 0; i < stats->nprocs(); i++){
     CkPrintf("[pestats] %d %g \n",
                                i,
                                objload[i]);
@@ -345,7 +345,7 @@ void MultistepLB::work2(BaseLB::LDStats *stats, int count){
   CkPrintf("******************************\n");
   CkPrintf("MEASURED CPU LOAD\n");
   CkPrintf("******************************\n");
-  for(int i = 0; i < stats->count; i++){
+  for(int i = 0; i < stats->nprocs(); i++){
     CkPrintf("[pestats] %d %g %g\n",
                                i,
                                stats->procs[i].total_walltime,

--- a/MultistepLB_notopo.cpp
+++ b/MultistepLB_notopo.cpp
@@ -43,7 +43,7 @@ void MultistepLB_notopo::makeActiveProcessorList(BaseLB::LDStats *stats, int num
   int objsPerProc = 8;
   int expandFactor = 4;
   int procsNeeded;
-  procsNeeded = expandFactor*numActiveObjs/objsPerProc > stats->count ? stats->count : expandFactor*numActiveObjs/objsPerProc;
+  procsNeeded = expandFactor*numActiveObjs/objsPerProc > stats->nprocs() ? stats->nprocs() : expandFactor*numActiveObjs/objsPerProc;
 
   /* currently, only the first procsNeeded procs are used - could do something more sophisticated here in the future - FIXME */
 #ifdef MCLBMSV
@@ -144,7 +144,7 @@ void MultistepLB_notopo::work(BaseLB::LDStats* stats)
   CkPrintf("making active processor list\n");
 #endif
   makeActiveProcessorList(stats, numActiveObjects);
-  count = stats->count;
+  count = stats->nprocs();
 
   // let the strategy take over on this modified instrumented data and processor information
   work2(stats,count);
@@ -206,7 +206,7 @@ void MultistepLB_notopo::work2(BaseLB::LDStats *stats, int count){
   CkAssert(numProcessed==nmig);
 
   orbPrepare(tpEvents, box, nmig, stats);
-  orbPartition(tpEvents,box,stats->count,tp_array, stats);
+  orbPartition(tpEvents,box,stats->nprocs(),tp_array, stats);
 
   refine(stats, numobjs);
 

--- a/Orb3dLB.cpp
+++ b/Orb3dLB.cpp
@@ -164,7 +164,7 @@ void Orb3dLB::work(BaseLB::LDStats* stats)
   CkPrintf("[orb3dlb] %d numnodes allocating %lu bytes for nodes\n", numnodes, numnodes*sizeof(Node));
   nodes.resize(numnodes);
 
-  for(int i = 0; i < stats->count; i++){
+  for(int i = 0; i < stats->nprocs(); i++){
     int t;
     int x,y,z;
     int node;
@@ -201,8 +201,8 @@ void Orb3dLB::work(BaseLB::LDStats* stats)
 
   /*
   int migr = 0;
-  float *objload = new float[stats->count];
-  for(int i = 0; i < stats->count; i++){
+  float *objload = new float[stats->nprocs()];
+  for(int i = 0; i < stats->nprocs(); i++){
     objload[i] = 0.0;
   }
   for(int i = 0; i < numobjs; i++){
@@ -214,7 +214,7 @@ void Orb3dLB::work(BaseLB::LDStats* stats)
   CkPrintf("Before LB step %d\n", step());
   CkPrintf("***************************\n");
   CkPrintf("i pe wall cpu idle bg_wall bg_cpu objload\n");
-  for(int i = 0; i < stats->count; i++){
+  for(int i = 0; i < stats->nprocs(); i++){
     CkPrintf("[pestats] %d %d %f %f %f %f\n",
                                i,
                                stats->procs[i].pe,

--- a/Orb3dLBCommon.h
+++ b/Orb3dLBCommon.h
@@ -317,7 +317,7 @@ class Orb3dCommon{
       if (node_partition) {
         maxPieceProc = dMaxBalance * nmig / CkNumNodes();
       } else {
-        maxPieceProc = dMaxBalance*nmig/stats->count;
+        maxPieceProc = dMaxBalance*nmig/stats->nprocs();
       }
 
       if(maxPieceProc < 1.0)
@@ -345,8 +345,8 @@ class Orb3dCommon{
 
       nextProc = 0;
 
-      procload.resize(stats->count);
-      for(int i = 0; i < stats->count; i++){
+      procload.resize(stats->nprocs());
+      for(int i = 0; i < stats->nprocs(); i++){
         procload[i] = stats->procs[i].bg_walltime;
       }
 
@@ -354,8 +354,8 @@ class Orb3dCommon{
 
     void refine(BaseLB::LDStats *stats, int numobjs){
 #ifdef DO_REFINE
-      int *from_procs = Refiner::AllocProcs(stats->count, stats);
-      int *to_procs = Refiner::AllocProcs(stats->count, stats);
+      int *from_procs = Refiner::AllocProcs(stats->nprocs(), stats);
+      int *to_procs = Refiner::AllocProcs(stats->nprocs(), stats);
 #endif
 
       int migr = 0;
@@ -372,7 +372,7 @@ class Orb3dCommon{
 #ifdef DO_REFINE
       CkPrintf("[orb3dlb_notopo] refine\n");
       Refiner refiner(1.050);
-      refiner.Refine(stats->count,stats,from_procs,to_procs);
+      refiner.Refine(stats->nprocs(),stats,from_procs,to_procs);
 
       for(int i = 0; i < numobjs; i++){
         if(to_procs[i] != from_procs[i]) numRefineMigrated++;
@@ -380,9 +380,9 @@ class Orb3dCommon{
       }
 #endif
 
-      double *predLoad = new double[stats->count];
-      double *predCount = new double[stats->count];
-      for(int i = 0; i < stats->count; i++){
+      double *predLoad = new double[stats->nprocs()];
+      double *predCount = new double[stats->nprocs()];
+      for(int i = 0; i < stats->nprocs(); i++){
         predLoad[i] = 0.0;
         predCount[i] = 0.0;
       }
@@ -420,7 +420,7 @@ class Orb3dCommon{
 
       CkPrintf("***************************\n");
       //  CkPrintf("Before LB step %d\n", step());
-      for(int i = 0; i < stats->count; i++){
+      for(int i = 0; i < stats->nprocs(); i++){
         double wallTime = stats->procs[i].total_walltime;
         double idleTime = stats->procs[i].idletime;
         double bgTime = stats->procs[i].bg_walltime;
@@ -459,21 +459,21 @@ class Orb3dCommon{
 
       }
 
-      avgWall /= stats->count;
-      avgIdle /= stats->count;
-      avgBg /= stats->count;
-      avgPred /= stats->count;
-      avgPiece /= stats->count;
+      avgWall /= stats->nprocs();
+      avgIdle /= stats->nprocs();
+      avgBg /= stats->nprocs();
+      avgPred /= stats->nprocs();
+      avgPiece /= stats->nprocs();
 
 #ifdef PRINT_LOAD_PERCENTILES
       double accumVar = 0;
       vector<double> objectWallTimes;
-      for(int i = 0; i < stats->count; i++){
+      for(int i = 0; i < stats->nprocs(); i++){
         double wallTime = stats->procs[i].total_walltime;
         objectWallTimes.push_back(wallTime);
         accumVar += (wallTime - avgWall) * (wallTime - avgWall);
       }
-      double stdDev = sqrt(accumVar / stats->count);
+      double stdDev = sqrt(accumVar / stats->nprocs());
       CkPrintf("Average load: %.3f\n", avgWall);
       CkPrintf("Standard deviation: %.3f\n", stdDev);
 
@@ -496,7 +496,7 @@ class Orb3dCommon{
       float minload, maxload, avgload;
       minload = maxload = procload[0];
       avgload = 0.0;
-      for(int i = 0; i < stats->count; i++){
+      for(int i = 0; i < stats->nprocs(); i++){
         CkPrintf("pe %d load %f box %f %f %f %f %f %f\n", i, procload[i], 
             procbox[i].lesser_corner.x,
             procbox[i].lesser_corner.y,
@@ -510,7 +510,7 @@ class Orb3dCommon{
         if(maxload < procload[i]) maxload = procload[i];
       }
 
-      avgload /= stats->count;
+      avgload /= stats->nprocs();
 
       CkPrintf("Orb3dLB_notopo stats: min %f max %f avg %f max/avg %f\n", minload, maxload, avgload, maxload/avgload);
 #endif

--- a/Orb3dLB_notopo.cpp
+++ b/Orb3dLB_notopo.cpp
@@ -105,7 +105,7 @@ void Orb3dLB_notopo::work(BaseLB::LDStats* stats)
   }
 
   orbPrepare(tpEvents, box, numobjs, stats);
-  orbPartition(tpEvents,box,stats->count, tps, stats);
+  orbPartition(tpEvents,box,stats->nprocs(), tps, stats);
   int mcount = 0;
 	for(int i = 0; i < numobjs; i++) {
     if (stats->to_proc[i] != stats->from_proc[i]) {
@@ -155,7 +155,6 @@ void Orb3dLB_notopo::work(BaseLB::LDStats* stats)
 
 void Orb3dLB_notopo::pupDump(PUP::er &p, BaseLB::LDStats *stats, vector<Event> *tpEvents){
   stats->pup(p);
-  p|stats->count;
   for(int i = XDIM; i <= ZDIM; i++){
     p|tpEvents[i];
   }


### PR DESCRIPTION
Accessing via a function allows the underlying implementation to
change, which Charm++ is doing to move away from raw memory
allocations.