### PR TITLE
Fix for getting output 0 arrays in correct order.

### DIFF
--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -3604,12 +3604,12 @@ void Main::writeOutput(int iStep)
     if(verbosity)
 	ckout << " took " << (CkWallTimer() - startTime) << " seconds."
 	      << endl;
-    // The following call is to get the particles in key order
-    // before the sort.
-    treeProxy.drift(0.0, 0, 0, 0.0, 0.0, 0, true, param.dMaxEnergy,
-                    CkCallbackResumeThread());
-    domainDecomp(0);
     if(param.nSteps != 0 && param.bDoDensity) {
+        // The following call is to get the particles in key order
+        // before the sort.
+        treeProxy.drift(0.0, 0, 0, 0.0, 0.0, 0, true, param.dMaxEnergy,
+                        CkCallbackResumeThread());
+        domainDecomp(0);
         buildTree(0);
 
 	if(verbosity)
@@ -3669,8 +3669,17 @@ void Main::writeOutput(int iStep)
 	    if(verbosity)
 		ckout << " took " << (CkWallTimer() - startTime) << " seconds."
 		      << endl;
-	    }
-	}
+        }
+    }
+    if(param.nSteps != 0) {     // Get particles back to home
+                                // processors for continuing the simulation.
+        // The following call is to get the particles in key order
+        // before the sort.
+        treeProxy.drift(0.0, 0, 0, 0.0, 0.0, 0, true, param.dMaxEnergy,
+                        CkCallbackResumeThread());
+        domainDecomp(0);
+    }
+        
     if(param.iBinaryOut == 6)
         writeNCXML(achFile);
     }


### PR DESCRIPTION
The extra arrays for "nSteps = 0" outputs could end up in tree order rather than particle order.