### PR TITLE
Revert "TreePiece::adjust(): dEtauDot also limits adiabatic heating. …

### DIFF
--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -1819,8 +1819,7 @@ void TreePiece::adjust(int iKickRung, int bEpsAccStep, int bGravStep,
           }
 #endif
 
-	  if (dEtauDot > 0.0) { /* Prevent rapid adiabatic cooling
-					  or heating */
+	  if (dEtauDot > 0.0 && p->PdV() < 0.0) { /* Prevent rapid adiabatic cooling */
 	      assert(p->PoverRho2() > 0.0);
 	      // Use P/rho as internal energy estimate since "u" may
 	      // be driven to 0 with cooling.


### PR DESCRIPTION
…(#282)"

This reverts commit d16c23bfe78eeeca6dc09f8ec93ec71e1e22f67e.

The excessive adiabatic heating was symptomatic of a diffusion
instability.