### PR TITLE
Memory access cleanups

### DIFF
--- a/InOutput.cpp
+++ b/InOutput.cpp
@@ -115,6 +115,7 @@ void load_tipsy_star(Tipsy::TipsyReader &r, GravityParticle &p)
     p.fStarMFracIron() = 0.098*sp.metals;
     p.fMassForm() = sp.mass;
     p.fTimeForm() = sp.tform;
+    p.iGasOrder() = -1;
 #ifdef COOLING_MOLECULARH 
     p.dStarLymanWerner() = 0.0;
 #endif
@@ -725,6 +726,7 @@ static void load_NC_star(std::string filename, int64_t startParticle,
     for(int i = 0; i < myNumStar; ++i) {
         myParts[i].fDensity = 0.0;
         myParts[i].iType = TYPE_STAR;
+        myParts[i].iGasOrder() = -1;
         myParts[i].extraData = &myStarParts[i];
         }
     load_NC_base(filename, startParticle, myNumStar, myParts);

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -1546,7 +1546,7 @@ void TreePiece::kick(int iKickRung, double dDelta[MAXRUNG+1],
                * Make sure that the flow is in the right direction
                * If all the mass becomes hot, switch to being single-phase
                */
-              if(massFlux > 0) { 
+              if(bGasCooling && (massFlux > 0)) {
                   if(dMultiPhaseMaxTime > 0 && p->massHot() < (0.5*p->mass)) {
                       double massFluxMin = duDelta[p->rung]*p->mass/dMultiPhaseMaxTime;
                       massFlux = (massFlux > massFluxMin ? massFlux : massFluxMin);
@@ -1676,8 +1676,10 @@ void TreePiece::kick(int iKickRung, double dDelta[MAXRUNG+1],
 	      CkAssert(p->u() >= 0.0);
 	      CkAssert(p->uPred() >= 0.0);
 #ifndef COOLING_NONE
-              CkAssert(p->u() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
-              CkAssert(p->uPred() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
+              if(bGasCooling) {
+                  CkAssert(p->u() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
+                  CkAssert(p->uPred() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
+              }
 #endif
 	      }
 	  p->velocity += dDelta[p->rung]*p->treeAcceleration;
@@ -2074,7 +2076,8 @@ void TreePiece::drift(double dDelta,  // time step in x containing
 		  // of timescale u/uDot.
                   else p->uHotPred() = uold*exp(p->uHotDot()*duDelta/uold);
 		  }
-              CkAssert(p->uHotPred() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
+              if(bGasCooling)
+                  CkAssert(p->uHotPred() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
 #endif
 #else
 	      p->uPred() += p->PdV()*duDelta;
@@ -2087,7 +2090,8 @@ void TreePiece::drift(double dDelta,  // time step in x containing
                   p->uPred() = dMaxEnergy;
               CkAssert(p->uPred() >= 0.0);
 #ifndef COOLING_NONE
-              CkAssert(p->uPred() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
+              if(bGasCooling)
+                  CkAssert(p->uPred() < LIGHTSPEED*LIGHTSPEED/dm->Cool->dErgPerGmUnit);
 #endif
 	      }
 #ifdef DIFFUSION

--- a/starform.cpp
+++ b/starform.cpp
@@ -304,7 +304,7 @@ GravityParticle *Stfm::FormStar(GravityParticle *p,  COOL *Cool, double dTime,
 
 #ifdef COOLING_MOLECULARH
     double dMprob;
-    if (dStarFormEfficiencyH2 == 0) dMprob  = 1.0 - exp(-dCStar*dTimeStarForm/tform);
+    if (!bGasCooling || dStarFormEfficiencyH2 == 0) dMprob  = 1.0 - exp(-dCStar*dTimeStarForm/tform);
     else dMprob = 1.0 - exp(-dCStar*dTimeStarForm/tform*
     			    dStarFormEfficiencyH2*p->CoolParticle().f_H2);    
     *H2FractionForm = p->CoolParticle().f_H2;


### PR DESCRIPTION
This includes
1) setting iGasOrder = -1 for initial stars.  Otherwise it will be undefined.
2) Avoiding accessing cooling structures for adiabatic simulations.