### PR TITLE
Move UserGravity calls out of Sph.cpp

### DIFF
--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2685,6 +2685,13 @@ void Main::setupICs() {
           }
       } 
   
+  // do the source terms
+  ckout << "Calculating user gravity source term ...";
+  startTime = CkWallTimer();
+  dMProxy.initUserGravity( param, CkCallbackResumeThread());
+  ckout << " took " << (CkWallTimer() - startTime) << " seconds."
+            << endl;
+
   param.externalGravity.CheckParams(prm, param);
 
   string achLogFileName = string(param.achOutName) + ".log";

--- a/Sph.cpp
+++ b/Sph.cpp
@@ -11,7 +11,6 @@
 #include "Sph.h"
 #include "SphUtils.h"
 #include "physconst.h"
-#include "UserGravity.h"
 #include "formatted_string.h"
 
 #include <float.h>
@@ -131,13 +130,6 @@ void Main::initCooling()
             }
         }
 #endif
-  // do the source terms
-  ckout << "Calculating source term ...";
-  double startTime = CkWallTimer();
-  dMProxy.initUserGravity( param, CkCallbackResumeThread());
-  ckout << " took " << (CkWallTimer() - startTime) << " seconds."
-            << endl;
-  
     }
 
 /**
@@ -180,16 +172,6 @@ DataManager::dmCoolTableRead(double *dTableData, int nData, const CkCallback& cb
 #endif
     contribute(cb);
     }
-
-void DataManager::initUserGravity( Parameters param, const CkCallback& cb) {
-  UserGravity::initUserGravityParameters( param);
-  UserGravity::initConstants( param.iUserGravityType, param.dSecUnit, (3.0857e21*param.dKpcUnit),
-      param.vPeriod.x, param.vPeriod.y, param.vPeriod.z);
-
-  UserGravity::initUserGravity();
-  contribute(cb);
-
-}
 
 ///
 /// @brief function from PKDGRAV to read an ASCII table

--- a/UserGravity.cpp
+++ b/UserGravity.cpp
@@ -4,7 +4,7 @@
 #include "UserPWGravity.h"
 #include "TurbulentDrivingSource.h"
 #include "physconst.h"
-//include "parameters.h"
+#include "ParallelGravity.h"
 #include <stdio.h>
 #include <math.h>
 
@@ -94,6 +94,16 @@ void UserRadGravity::getGravity( double t, double x, double y, double z, double&
 void UserZGravity::initializeParameters( Parameters param){
   gravLengthScale = param.dgravL;
   zGravity = param.dgrav;
+}
+
+void DataManager::initUserGravity( Parameters param, const CkCallback& cb) {
+  UserGravity::initUserGravityParameters( param);
+  UserGravity::initConstants( param.iUserGravityType, param.dSecUnit, (3.0857e21*param.dKpcUnit),
+      param.vPeriod.x, param.vPeriod.y, param.vPeriod.z);
+
+  UserGravity::initUserGravity();
+  contribute(cb);
+
 }
 
 void UserZGravity::getGravity( double t, double x, double y, double z, double& gx, double& gy, double& gz, double &dtg) {


### PR DESCRIPTION
This also fixes an uninitialized memory problem in the parameters structure.