### PR TITLE
Read nsidm array if restarting from output.

### DIFF
--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2295,6 +2295,7 @@ void Main::setupICs() {
       if (param.iSIDMSelect==2){ //only for classical regime do this
           param.dSIDMVariable=param.dSIDMVariable/(pow(param.dMsolUnit*MSOLG*GCGS/(KPCCM*param.dKpcUnit),.5)/100000.0) ; //converts from km/s to sim units
           }
+      if(param.iStartStep) restartNSIDM();
       } 
   
   param.externalGravity.CheckParams(prm, param);

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2294,9 +2294,11 @@ void Main::setupICs() {
       param.dSIDMSigma=param.dSIDMSigma*param.dMsolUnit*MSOLG/(param.dKpcUnit*KPCCM*param.dKpcUnit*KPCCM); //converts input cross section in cm^2 g^-1 to simulation units in len_unit^2 / mass_unit
       if (param.iSIDMSelect==2){ //only for classical regime do this
           param.dSIDMVariable=param.dSIDMVariable/(pow(param.dMsolUnit*MSOLG*GCGS/(KPCCM*param.dKpcUnit),.5)/100000.0) ; //converts from km/s to sim units
-          }
+      }
+      // iStartStep != 0 indicates we are restarting from an output:
+      // read in extra information.
       if(param.iStartStep) restartNSIDM();
-      } 
+  }
   
   param.externalGravity.CheckParams(prm, param);
 

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -605,6 +605,7 @@ public:
 	void pup(PUP::er& p);
 	void liveVizImagePrep(liveVizRequestMsg *msg);
         void doSIDM(double dTime,double dDelta, int activeRung); /* SIDM */
+        void restartNSIDM();
 };
 
 /* IBM brain damage */

--- a/SIDM.cpp
+++ b/SIDM.cpp
@@ -39,7 +39,6 @@ Main::restartNSIDM()
             CkError("WARNING: no NSIDM file, or wrong format for restart\n");
     } else {
         // Assume TIPSY arrays
-        // read iOrder
         if(arrayFileExists(basefilename + ".nsidm", nTotalParticles)) {
             iNSIDMOutputParams pNSIDMOut(basefilename, 0, 0.0);
             treeProxy.readTipsyArray(pNSIDMOut, CkCallbackResumeThread());

--- a/SIDM.cpp
+++ b/SIDM.cpp
@@ -9,6 +9,48 @@
 #include "smooth.h"
 #include "SIDM.h"
 
+#include <sys/stat.h>
+bool arrayFileExists(const std::string filename, const int64_t count) ;
+/**
+ *  @brief Read in array files for SIDM interact count, if needed
+ */
+void
+Main::restartNSIDM()
+{
+#ifdef SIDMINTERACT
+    // The following is needed only if we are tracking the number of
+    // interactions
+    if(verbosity)
+        CkPrintf("Restarting NSIDM with array files.\n");
+
+    struct stat s;
+    int err = stat(basefilename.c_str(), &s);
+    if(err != -1 && S_ISDIR(s.st_mode)) {
+        // The file is a directory; assume NChilada
+        int64_t nDark = 0;
+        if(nTotalDark > 0)
+            nDark = ncGetCount(basefilename + "/dark/nsidm");
+        if(nDark == nTotalDark) {
+            iNSIDMOutputParams pNSIDMOut(basefilename, 6, 0.0);
+            treeProxy.readFloatBinary(pNSIDMOut, param.bParaRead,
+                                      CkCallbackResumeThread());
+        }
+        else
+            CkError("WARNING: no NSIDM file, or wrong format for restart\n");
+    } else {
+        // Assume TIPSY arrays
+        // read iOrder
+        if(arrayFileExists(basefilename + ".nsidm", nTotalParticles)) {
+            iNSIDMOutputParams pNSIDMOut(basefilename, 0, 0.0);
+            treeProxy.readTipsyArray(pNSIDMOut, CkCallbackResumeThread());
+        }
+        else {
+            CkError("WARNING: no igasorder file for restart\n");
+        }
+    }
+#endif
+}
+
 ///
 /// @brief Main method to perform Self Interacting Dark Matter interactions
 /// @param dTime current simulation time


### PR DESCRIPTION
This only is done if SIDM interactions are being counted.
This keeps track of the interaction count across restarts from outputs.
