### PR TITLE
TreePiece::updateuDot(): use uPred and uHotPred in PoverRho calculation.

### DIFF
--- a/Sph.cpp
+++ b/Sph.cpp
@@ -894,7 +894,7 @@ void TreePiece::updateuDot(int activeRung,
         }
 #ifdef SUPERBUBBLE
         double frac = p->massHot()/p->mass;
-        PoverRhoGas = gammam1*(p->uHot()*frac+p->u()*(1-frac));
+        PoverRhoGas = gammam1*(p->uHotPred()*frac+p->uPred()*(1-frac));
 #endif
         PoverRhoJeans = PoverRhoFloorJeans(dResolveJeans, p);
         PoverRho = PoverRhoGas;


### PR DESCRIPTION
This patch makes this code match what is in the changa_uw fork.