### PR TITLE
Added mf2.py in testcosmo

### DIFF
--- a/testcosmo/README
+++ b/testcosmo/README
@@ -15,7 +15,7 @@ takes 15 minutes to run on a 2007 era dual core processor.
 
 4) After running ChaNGa and making the modifications in 1, type
 "mf.sh" at the prompt to check the results.  It runs SKID and SO on
-the results, and then calls an IDL program (mf2.pro) to compare the
+the results, and then calls a python script (mf2.py) to compare the
 resulting mass function to the expected mass function.
 
   - If the mass function matches that expected, a congratulatory statement is 

--- a/testcosmo/mf.sh
+++ b/testcosmo/mf.sh
@@ -8,9 +8,9 @@ SODIR=XXX
 # end of edits
 #
 echo "SKIDDING outputs"
-$SKIDDIR/skid -tau 0.005  -std -O 0.3 -H 2.894405 -s 12 -m 16 -o cube300.00128.skid -stats <cube300.000128
+$SKIDDIR/skid -tau 0.005  -std -O 0.3 -H 2.894405 -s 12 -m 16 -o cube300.000128.skid -stats <cube300.000128
 echo "Moving to SO"
-$SODIR/so -i cube300.00128.skid.gtp  -o cube300.00128.so -all -std -grp -gtp -stat cube300.00128.skid.stat -m 16 -O 0.3 -L  -p 1 -u 3.672e18 300 < cube300.000128
+$SODIR/so -i cube300.000128.skid.gtp  -o cube300.000128.so -all -std -grp -gtp -stat cube300.000128.skid.stat -m 16 -O 0.3 -L  -p 1 -u 3.672e18 300 < cube300.000128
 echo "SO complete"
 echo "Moving to Mass Function comparison"
-idl idl.mf.batch
+python3 mf2.py cube300.000.so.sovcirc

--- a/testcosmo/mf.sh
+++ b/testcosmo/mf.sh
@@ -13,4 +13,4 @@ echo "Moving to SO"
 $SODIR/so -i cube300.000128.skid.gtp  -o cube300.000128.so -all -std -grp -gtp -stat cube300.000128.skid.stat -m 16 -O 0.3 -L  -p 1 -u 3.672e18 300 < cube300.000128
 echo "SO complete"
 echo "Moving to Mass Function comparison"
-python3 mf2.py cube300.000128.so.sovcirc
+python mf2.py cube300.000128.so.sovcirc

--- a/testcosmo/mf.sh
+++ b/testcosmo/mf.sh
@@ -13,4 +13,4 @@ echo "Moving to SO"
 $SODIR/so -i cube300.000128.skid.gtp  -o cube300.000128.so -all -std -grp -gtp -stat cube300.000128.skid.stat -m 16 -O 0.3 -L  -p 1 -u 3.672e18 300 < cube300.000128
 echo "SO complete"
 echo "Moving to Mass Function comparison"
-python3 mf2.py cube300.000.so.sovcirc
+python3 mf2.py cube300.000128.so.sovcirc

--- a/testcosmo/mf2.py
+++ b/testcosmo/mf2.py
@@ -43,4 +43,4 @@ if logn_pe<5:
 else:
     print("PROBLEM!  This mass function differs from predicted by more than 5%!")
 
-print("The largest error is %.2f%%." % (logn_pe))
+print("The largest error is %.2f%%.\n" % (logn_pe))

--- a/testcosmo/mf2.py
+++ b/testcosmo/mf2.py
@@ -1,0 +1,46 @@
+#run with the catalogue as an input file
+#   python3 mf2.py "path to catalogue"
+
+
+
+import sys
+import numpy as np
+
+#previously determined cumulative mass function against which the input file will be compared
+test_logm = np.array([14.1744, 14.4744, 14.7744, 15.0744, 15.3744])
+test_logn = np.array([-5.1217, -5.5176, -6.0164, -6.4314, -7.4314])
+cube_side = 300
+
+
+#define a function that takes in an array of halos and returns an array that only containts those with a mass greater than M
+def greater_than_mass(M, mn_array):
+    return mn_array[:,1][(mn_array[:,1]>M)]
+
+#load in the data from the input file
+catalogue=np.loadtxt(sys.argv[1])
+
+
+#pull out just the mass and the number of each halo
+mvsn = catalogue[:,0:3]
+
+
+#find the cumulative mass function at values of the mass that match the test function
+mfc=np.zeros(test_logm.size)
+for i in range(test_logm.size):
+    n_greater=greater_than_mass(10**test_logm[i], mvsn).size
+    mfc[i]=n_greater
+
+#convert number into log of number density
+mf_units = mfc/cube_side**3
+logn=np.log10(mf_units)
+
+#find percent error from the test function
+logn_pe = np.max(np.abs((logn-test_logn)/test_logn)*100)
+
+if logn_pe<5:
+    print("Congrats! This simulation produces a mass function as predicted!")
+    
+else:
+    print("PROBLEM!  This mass function differs from predicted by more than 5%!")
+
+print("The largest error is %.2f%%." % (logn_pe))


### PR DESCRIPTION
Added mf2.py, which is a python script that will test the simulation as a replacement for mf2.pro. Also modified mf.sh to make it run the new script, and to change some output file names from cube300.00128 that currently cause problems. 