### PR TITLE
Use tree for key to node lookups instead of std::map.

### DIFF
--- a/Compute.cpp
+++ b/Compute.cpp
@@ -2359,14 +2359,6 @@ void printUndlist(DoubleWalkState *state, int level, TreePiece *tp){
 
 #endif // INTERLIST_VER > 0
 
-void RemoteTreeBuilder::registerNode(GenericTreeNode *node){
-  tp->nodeLookupTable[node->getKey()] = node;
-}
-
-void LocalTreeBuilder::registerNode(GenericTreeNode *node){
-  tp->nodeLookupTable[node->getKey()] = node;
-}
-
 bool RemoteTreeBuilder::work(GenericTreeNode *node, int level){
   CkAssert(node != NULL);
   CkAssert(node->isValid() && !node->isCached());
@@ -2397,7 +2389,6 @@ bool RemoteTreeBuilder::work(GenericTreeNode *node, int level){
           streamingProxy[node->remoteIndex].requestRemoteMoments(node->getKey(), tp->thisIndex, &opts);
         }
       }
-      registerNode(node);
       return false;
     }
 
@@ -2413,7 +2404,6 @@ bool RemoteTreeBuilder::work(GenericTreeNode *node, int level){
       // from the particle positions.
       node->boundingBox.reset();
 
-      registerNode(node);
       return true;
 
     default:
@@ -2486,7 +2476,6 @@ bool LocalTreeBuilder::work(GenericTreeNode *node, int level){
       tp->bucketList.push_back(node);
       tp->numBuckets++;
 
-      registerNode(node);
       // deliver moments, since doneChildren() will
       // never be called with a bucket
       tp->deliverMomentsToClients(node);
@@ -2495,7 +2484,6 @@ bool LocalTreeBuilder::work(GenericTreeNode *node, int level){
   else if(node->getType() == Empty){
     node->remoteIndex = tp->thisIndex;
 
-    registerNode(node);
     // deliver MomentsToClients, since remote pieces don't know its
     // an empty node.
     tp->deliverMomentsToClients(node);
@@ -2510,7 +2498,6 @@ bool LocalTreeBuilder::work(GenericTreeNode *node, int level){
     node->boundingBox.reset();
     node->remoteIndex = tp->thisIndex;
 
-    registerNode(node);
     // don't deliver MomentsToClients, since we
     // haven't yet computed the moments for this 
     // node: this will happen only after the moments

--- a/Compute.h
+++ b/Compute.h
@@ -295,10 +295,6 @@ class RemoteTreeBuilder : public TreeNodeWorker {
 
   bool work(GenericTreeNode *node, int level);
   void doneChildren(GenericTreeNode *node, int level);
-
-  private:
-  void registerNode(GenericTreeNode *node);
-
 };
 
 /// @brief Class to build the local part of the tree.  Builds Internal nodes.
@@ -312,9 +308,6 @@ class LocalTreeBuilder : public TreeNodeWorker {
 
   bool work(GenericTreeNode *node, int level);
   void doneChildren(GenericTreeNode *node, int level);
-
-  private:
-  void registerNode(GenericTreeNode *node);
 };
 
 /** @brief TreeNodeWorker implementation that just prints out the

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -201,10 +201,6 @@ void DataManager::combineLocalTrees(CkReductionMsg *msg) {
     }
     nodeTable.clear();
 
-#ifdef CUDA
-    cumNumReplicatedNodes = 0;
-#endif
-
     CkVec<Tree::GenericTreeNode*> gtn;
     for(int i = 0; i < registeredTreePieces.length(); i++){
       gtn.push_back(registeredTreePieces[i].root);
@@ -317,9 +313,6 @@ const char *typeString(NodeType type);
  * to the copies in each treepiece of an identical node.
  */
 Tree::GenericTreeNode *DataManager::buildProcessorTree(int n, Tree::GenericTreeNode **gtn) {
-#ifdef CUDA
-  cumNumReplicatedNodes += (n-1);
-#endif
   int nUnresolved;
   int pickedIndex;
   GenericTreeNode *pickedNode = pickNodeFromMergeList(n,gtn,nUnresolved,pickedIndex);
@@ -786,22 +779,18 @@ void DataManager::serializeLocal(GenericTreeNode *node){
   CkQ<GenericTreeNode *> queue;
 
   int numTreePieces = registeredTreePieces.length();
-  int numNodes = 0;
   int numParticles = 0;
   int numCachedNodes = 0;
   int numCachedParticles = 0;
 
   for(int i = 0; i < numTreePieces; i++){
     TreePiece *tp = registeredTreePieces[i].treePiece;
-    numNodes += tp->getNumNodes();
     numParticles += tp->getDMNumParticles();
   }
-  numNodes -= cumNumReplicatedNodes;
 
   CkVec<CudaMultipoleMoments> localMoments;
   CkVec<CompactPartData> localParticles;
 
-  localMoments.reserve(numNodes);
   localParticles.resize(numParticles);
 
   localMoments.length() = 0;

--- a/DataManager.h
+++ b/DataManager.h
@@ -79,10 +79,6 @@ protected:
 	// holds chare array indices of registered treepieces
 	CkVec<TreePieceDescriptor> registeredTreePieces;
 #ifdef CUDA
-	//CkVec<int> registeredTreePieceIndices;
-        /// @brief counter for the number of tree nodes that are
-        /// replicated by TreePieces that share the same address space.
-        int cumNumReplicatedNodes;
         int treePiecesDone;
         int savedChunk;
         int treePiecesDonePrefetch;

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -2772,7 +2772,6 @@ void TreePiece::startORBTreeBuild(CkReductionMsg* m){
   if (thisIndex == 0) root->firstParticle ++;
   if (thisIndex == (int)numTreePieces-1) root->lastParticle --;
   root->particleCount = myNumParticles;
-  nodeLookupTable[(Tree::NodeKey)1] = root;
 
   //root->key = firstPossibleKey;
   root->boundingBox = boundingBox;
@@ -2879,7 +2878,6 @@ void TreePiece::buildORBTree(GenericTreeNode * node, int level){
 #if INTERLIST_VER > 0
     child->startBucket=numBuckets;
 #endif
-    nodeLookupTable[child->getKey()] = child;
     if (child->getType() == NonLocal) {
       // find a remote index for the node
       int first, last;
@@ -3036,7 +3034,6 @@ void TreePiece::startOctTreeBuild(CkReductionMsg* m) {
   if (myPlace == 0) root->firstParticle ++;
   if (myPlace == dm->responsibleIndex.size()-1) root->lastParticle --;
   root->particleCount = myNumParticles;
-  nodeLookupTable[(Tree::NodeKey)1] = root;
 
   root->boundingBox = boundingBox;
   numBuckets = 0;
@@ -5793,17 +5790,6 @@ void TreePiece::pup(PUP::er& p) {
       ckout << " size: " << ((PUP::sizer*)&p)->size();
       ckout << endl;
       }
-  }
-}
-
-void TreePiece::reconstructNodeLookup(GenericTreeNode *node) {
-  nodeLookupTable[node->getKey()] = node;
-  node->particlePointer = &myParticles[node->firstParticle];
-  if (node->getType() == Bucket) bucketList.push_back(node);
-  GenericTreeNode *child;
-  for (unsigned int i=0; i<node->numChildren(); ++i) {
-    child = node->getChildren(i);
-    if (child != NULL) reconstructNodeLookup(child);
   }
 }
 


### PR DESCRIPTION
This may be a space saver, but there may be performance implications, so do some benchmarks before merging.
This includes benchmarking the GPU code.