### PR TITLE
Fix GPU memory transfer + EwaldInit race condition

### DIFF
--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -511,7 +511,7 @@ void DataManager::startLocalWalk() {
       int in = registeredTreePieces[i].treePiece->getIndex();
       treePieces[in].commenceCalculateGravityLocal();
       if(registeredTreePieces[0].treePiece->bEwald) {
-          EwaldMsg *msg = new EwaldMsg;
+          EwaldMsg *msg = new (8*sizeof(int)) EwaldMsg;
           msg->fromInit = false;
           // Make priority lower than gravity or smooth.
           *((int *)CkPriorityPtr(msg)) = 3*numTreePieces + in + 1;

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -47,7 +47,6 @@ void DataManager::init() {
   treePiecesDoneRemoteChunkComputation = 0;
   treePiecesWantParticlesBack = 0;
   treePiecesParticlesUpdated = 0;
-  gputransfer = false;
 #ifdef HAPI_INSTRUMENT_WRS
   treePiecesDoneInitInstrumentation = 0;
 #endif
@@ -506,14 +505,14 @@ void DataManager::serializeLocalTree(){
 /// Indicate the transfer is done, and start the local gravity walks
 /// on the treepieces on this node.
 void DataManager::startLocalWalk() {
-    gputransfer = true;
     delete localTransferCallback;
     for(int i = 0; i < registeredTreePieces.length(); i++){
       if(verbosity > 1) CkPrintf("[%d] GravityLocal %d\n", CkMyPe(), i);
       int in = registeredTreePieces[i].treePiece->getIndex();
       treePieces[in].commenceCalculateGravityLocal();
       if(registeredTreePieces[0].treePiece->bEwald) {
-          dummyMsg *msg = new (8*sizeof(int)) dummyMsg;
+          EwaldMsg *msg = new EwaldMsg;
+          msg->fromInit = false;
           // Make priority lower than gravity or smooth.
           *((int *)CkPriorityPtr(msg)) = 3*numTreePieces + in + 1;
           CkSetQueueing(msg,CK_QUEUEING_IFIFO);
@@ -1105,7 +1104,6 @@ void DataManager::transferParticleVarsBack(){
                              savedNumTotalParticles > 0, lastChunkMoments > 0,
                              lastChunkParticles > 0);
 #endif
-    gputransfer = false;
   }
   CmiUnlock(__nodelock);
 }

--- a/DataManager.h
+++ b/DataManager.h
@@ -112,8 +112,6 @@ protected:
         // can the gpu accept a chunk of remote particles/nodes?
         bool gpuFree;
 
-        // This var will indicate if particle data has been loaded to the GPU
-        bool gputransfer;
         /// Callback pointer to pass to HAPI.
         CkCallback *localTransferCallback;
 

--- a/Ewald.cpp
+++ b/Ewald.cpp
@@ -374,7 +374,7 @@ void TreePiece::EwaldInit()
 		}
 	nEwhLoop = i;
 
-	EwaldMsg *msg = new EwaldMsg;
+	EwaldMsg *msg = new (8*sizeof(int)) EwaldMsg;
         msg->fromInit = true;
         // Make priority lower than gravity or smooth.
 	*((int *)CkPriorityPtr(msg)) = 3*numTreePieces * numChunks + thisIndex + 1;

--- a/Ewald.cpp
+++ b/Ewald.cpp
@@ -373,9 +373,9 @@ void TreePiece::EwaldInit()
 			}
 		}
 	nEwhLoop = i;
-        bEwaldInited = true;
 
-	dummyMsg *msg = new (8*sizeof(int)) dummyMsg;
+	EwaldMsg *msg = new EwaldMsg;
+        msg->fromInit = true;
         // Make priority lower than gravity or smooth.
 	*((int *)CkPriorityPtr(msg)) = 3*numTreePieces * numChunks + thisIndex + 1;
 	CkSetQueueing(msg,CK_QUEUEING_IFIFO);

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -83,6 +83,11 @@ mainmodule ParallelGravity {
   message dummyMsg;
   message ComputeChunkMsg;
 
+  message EwaldMsg{
+    bool fromInit;
+  };
+
+
   message ORBSplittersMsg{
     double pos[];
     char dim[];
@@ -274,7 +279,7 @@ mainmodule ParallelGravity {
                            int bComove, double dRhoFac);
     entry [notrace] void EwaldInit();
     entry [notrace] void initCoolingData(const CkCallback& cb);
-    entry void calculateEwald(dummyMsg *m);
+    entry void calculateEwald(EwaldMsg *m);
     entry [notrace] void EwaldGPUComplete(); 
     entry [notrace] void EwaldGPU(); 
     entry void velScale(double dScale, const CkCallback& cb);

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -326,7 +326,7 @@ struct BucketMsg : public CkMcastBaseMsg, public CMessage_BucketMsg {
 };
 #endif
 
-struct EwaldMsg: public CkMcastBaseMsg, public CMessage_EwaldMsg {
+struct EwaldMsg: public CMessage_EwaldMsg {
     bool fromInit;
 };
     

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -325,6 +325,10 @@ struct BucketMsg : public CkMcastBaseMsg, public CMessage_BucketMsg {
   int whichTreePiece;
 };
 #endif
+
+struct EwaldMsg: public CkMcastBaseMsg, public CMessage_EwaldMsg {
+    bool fromInit;
+};
     
 /// Class to count added and deleted particles
 class CountSetPart 
@@ -1213,8 +1217,6 @@ private:
 #ifdef HEXADECAPOLE
 	MOMC momcRoot;		/* complete moments of root */
 #endif
-        /// Have the Ewald h loop tables been calculated.
-        bool bEwaldInited;
 
 	int bGasCooling;
 #ifndef COOLING_NONE
@@ -1475,7 +1477,6 @@ public:
 	  prefetchRoots = NULL;
 	  ewt = NULL;
 	  nMaxEwhLoop = 100;
-          bEwaldInited = false;
 
           incomingParticlesMsg.clear();
           incomingParticlesArrived = 0;
@@ -1516,7 +1517,6 @@ public:
 	  prefetchRoots = NULL;
 	  //remaining Chunk = NULL;
           ewt = NULL;
-          bEwaldInited = false;
 	  root = NULL;
 	  pTreeNodes = NULL;
 
@@ -1584,8 +1584,8 @@ public:
                          int bComove, double dRhoFac);
 	void BucketEwald(GenericTreeNode *req, int nReps,double fEwCut);
 	void EwaldInit();
-	void calculateEwald(dummyMsg *m);
-  void calculateEwaldUsingCkLoop(dummyMsg *msg, int yield_num);
+	void calculateEwald(EwaldMsg *m);
+  void calculateEwaldUsingCkLoop(int yield_num);
   void callBucketEwald(int id);
   void doParallelNextBucketWork(int id, LoopParData* lpdata);
 	void initCoolingData(const CkCallback& cb);

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -4095,11 +4095,10 @@ void TreePiece::calculateGravityLocal() {
   doAllBuckets();
 }
 
-void TreePiece::calculateEwald(dummyMsg *msg) {
+void TreePiece::calculateEwald(EwaldMsg *msg) {
 #ifdef SPCUDA
-  if(dm->gputransfer && bEwaldInited){
+  if(!msg->fromInit){
     thisProxy[thisIndex].EwaldGPU();
-    bEwaldInited = false;
   }
   delete msg;
 #else
@@ -4112,7 +4111,7 @@ void TreePiece::calculateEwald(dummyMsg *msg) {
     // This value was chosen to be32*Nodesize so that we have enough buckets for
     // all the PEs in the node and also giving some extra for load balance.
     yield_num = 3 * CkMyNodeSize();
-    calculateEwaldUsingCkLoop(msg, yield_num);
+    calculateEwaldUsingCkLoop(yield_num);
   }
 
   unsigned int i=0;
@@ -4159,7 +4158,7 @@ void doCalcEwald(int start, int end, void *result, int pnum, void * param) {
   *(double *)result = tend - tstart;
 }
 
-void TreePiece::calculateEwaldUsingCkLoop(dummyMsg *msg, int yield_num) {
+void TreePiece::calculateEwaldUsingCkLoop(int yield_num) {
   unsigned int i=0;
   LoopParData* lpdata = new LoopParData();
   lpdata->tp = this;


### PR DESCRIPTION
This fixes a race condition where serializeLocal can sometimes be invoked before EwaldInit finishes. An EwaldMsg object is now passed to EwaldGPU, which tells whether EwaldInit, or the callback from the GPU memory transfer invoked it.

Note that the EwaldMsg only contains a single field here. EwaldMsg is used more extensively after the WorkRequest code has been removed from ChaNGa. These changes are contained in a separate pull request.