### PR TITLE
Starlog::logMetaData(): fix small format error for H2FracForm

### DIFF
--- a/starform.cpp
+++ b/starform.cpp
@@ -510,7 +510,7 @@ void StarLog::logMetaData(std::ofstream &osfLog)
     osfLog << "# rhoForm f" << sizeof(double) << endl;
     osfLog << "# TForm f" << sizeof(double) << endl;
 #ifdef COOLING_MOLECULARH 
-    osfLog <<" #  H2FracForm f" << sizeof(double) << endl;
+    osfLog << "# H2FracForm f" << sizeof(double) << endl;
 #endif
     osfLog << "# end starlog data\n";
 }


### PR DESCRIPTION
Long standing format problem reported in the changa_uw fork.

N.B. This probably doesn't fix the problem reported on ~ 1/22/23 on slack.