### PR TITLE
Assign GPUs to PEs based on node ID

### DIFF
--- a/DataManager.h
+++ b/DataManager.h
@@ -313,6 +313,11 @@ inline static void setBIconfig()
 class ProjectionsControl : public CBase_ProjectionsControl { 
   public: 
   ProjectionsControl() {
+#ifdef CUDA
+    int numGpus;
+    cudaGetDeviceCount(&numGpus);
+    cudaSetDevice(CmiMyNode() % numGpus);
+#endif
     setBIconfig();
     LBTurnCommOff();
 #ifndef LB_MANAGER_VERSION

--- a/DataManager.h
+++ b/DataManager.h
@@ -314,6 +314,10 @@ class ProjectionsControl : public CBase_ProjectionsControl {
   public: 
   ProjectionsControl() {
 #ifdef CUDA
+    // GPUs are assigned to nodes in a round-robin fashion. This allows the user to define
+    // one virtual node per device and utilize multiple GPUs on a single node
+    // Beacuse devices are assigned per-PE, this is a convenient place to call setDevice
+    // Note that this code has nothing to do with initalizing projections
     int numGpus;
     cudaGetDeviceCount(&numGpus);
     cudaSetDevice(CmiMyNode() % numGpus);


### PR DESCRIPTION
Currently, PEs only utilize a single GPU per physical node, even if multiple devices are available. With this change, the user can split a physical node into virtual nodes and each virtual node will utilize a different GPU.

Note that using virtual nodes in SMP mode with projections enabled currently causes a CUDA memory error. This issue, however, is unrelated to the changes in this PR.