### PR TITLE
Flexible GPU and CPU Usage for Gravity

### DIFF
--- a/Compute.cpp
+++ b/Compute.cpp
@@ -1935,7 +1935,6 @@ void ListCompute::stateReadyPar(TreePiece *tp, int start, int end,
     CkVec<LocalPartInfo>& lpilist) {
 
 #ifndef CUDA
-  // TODO fix
   bool hasRemoteLists = rpilist.length() > 0 ? true : false;
   bool hasLocalLists = lpilist.length() > 0 ? true : false;
 

--- a/Compute.cpp
+++ b/Compute.cpp
@@ -1571,7 +1571,7 @@ void ListCompute::stateReady(State *state_, TreePiece *tp, int chunk, int start,
 #ifdef CUDA
   if (bUseCpu)
 #endif
-  { // This block executes if we are preparing to to gravity on the CPU
+  { // This block executes if we are preparing do to gravity on the CPU
     for(int b = start; b < end; b++){
       if(tp->bucketList[b]->rungs >= activeRung){
 

--- a/Compute.cpp
+++ b/Compute.cpp
@@ -1569,7 +1569,7 @@ void ListCompute::stateReady(State *state_, TreePiece *tp, int chunk, int start,
 #endif
 
   if (bUseCpu)
-  { // This block executes if we are preparing do to gravity on the CPU
+  { // This block executes if we are doing gravity on the CPU
     for(int b = start; b < end; b++){
       if(tp->bucketList[b]->rungs >= activeRung){
 

--- a/Compute.cpp
+++ b/Compute.cpp
@@ -1568,9 +1568,7 @@ void ListCompute::stateReady(State *state_, TreePiece *tp, int chunk, int start,
     CmiMemoryCheck();
 #endif
 
-#ifdef CUDA
   if (bUseCpu)
-#endif
   { // This block executes if we are preparing do to gravity on the CPU
     for(int b = start; b < end; b++){
       if(tp->bucketList[b]->rungs >= activeRung){

--- a/Compute.h
+++ b/Compute.h
@@ -183,6 +183,7 @@ class ListCompute : public Compute{
   State *getNewState();
   void freeState(State *state);
   void freeDoubleWalkState(DoubleWalkState *state);
+  /// Flag the cpu (instead of gpu) for usage for the next walk
   void enableCpu() {bUseCpu = 1;}
 
 #ifdef CUDA
@@ -199,7 +200,7 @@ class ListCompute : public Compute{
   void addNodeToInt(GenericTreeNode *node, int offsetID, DoubleWalkState *s);
 
   DoubleWalkState *allocDoubleWalkState();
-  // used to flag cpu for usage when compiling with CUDA enabled
+  /// used to flag cpu (instead of gpu) for usage when compiling with CUDA
   int bUseCpu;
 
 #if defined CHANGA_REFACTOR_PRINT_INTERACTIONS || defined CHANGA_REFACTOR_WALKCHECK_INTERLIST || defined CUDA

--- a/Compute.h
+++ b/Compute.h
@@ -165,6 +165,8 @@ class ListCompute : public Compute{
 
   void initState(State *state);
 
+  void helper(DoubleWalkState *state, TreePiece *tp, int chunk, int start,
+                         int end, int maxlevel, bool hasRemoteLists, bool hasLocalLists);
   void stateReady(State *, TreePiece *, int chunk, int start, int end);
 
   void stateReadyPar(TreePiece *tp, int start, int end,

--- a/Compute.h
+++ b/Compute.h
@@ -148,7 +148,11 @@ class GravityCompute : public Compute{
 class ListCompute : public Compute{
 
   public:
-  ListCompute() : Compute(List) {}
+  ListCompute() : Compute(List) {
+#ifdef CUDA
+    bUseGpu = 1;
+#endif
+  }
 
   int doWork(GenericTreeNode *, TreeWalk *tw, State *state, int chunk, int reqID, bool isRoot, bool &didcomp, int awi);
 
@@ -186,6 +190,7 @@ class ListCompute : public Compute{
 #endif //GPU_LOCAL_TREE_WALK
   void sendNodeInteractionsToGpu(DoubleWalkState *state, TreePiece *tp);
   void sendPartInteractionsToGpu(DoubleWalkState *state, TreePiece *tp);
+  void disableGpu() {bUseGpu = 0;}
 #endif
 
   private:
@@ -194,6 +199,10 @@ class ListCompute : public Compute{
   void addNodeToInt(GenericTreeNode *node, int offsetID, DoubleWalkState *s);
 
   DoubleWalkState *allocDoubleWalkState();
+#ifdef CUDA
+  // used to flag cpu for usage when compiling with CUDA enabled
+  int bUseGpu;
+#endif
 
 #if defined CHANGA_REFACTOR_PRINT_INTERACTIONS || defined CHANGA_REFACTOR_WALKCHECK_INTERLIST || defined CUDA
   void addRemoteParticlesToInt(ExternalGravityParticle *parts, int n,

--- a/Compute.h
+++ b/Compute.h
@@ -163,8 +163,6 @@ class ListCompute : public Compute{
 
   void initState(State *state);
 
-  void helper(DoubleWalkState *state, TreePiece *tp, int chunk, int start,
-                         int end, int maxlevel, bool hasRemoteLists, bool hasLocalLists);
   void stateReady(State *, TreePiece *, int chunk, int start, int end);
 
   void stateReadyPar(TreePiece *tp, int start, int end,

--- a/Compute.h
+++ b/Compute.h
@@ -149,9 +149,7 @@ class ListCompute : public Compute{
 
   public:
   ListCompute() : Compute(List) {
-#ifdef CUDA
-    bUseGpu = 1;
-#endif
+  bUseCpu = 0;
   }
 
   int doWork(GenericTreeNode *, TreeWalk *tw, State *state, int chunk, int reqID, bool isRoot, bool &didcomp, int awi);
@@ -185,6 +183,7 @@ class ListCompute : public Compute{
   State *getNewState();
   void freeState(State *state);
   void freeDoubleWalkState(DoubleWalkState *state);
+  void enableCpu() {bUseCpu = 1;}
 
 #ifdef CUDA
 #ifdef GPU_LOCAL_TREE_WALK
@@ -192,7 +191,6 @@ class ListCompute : public Compute{
 #endif //GPU_LOCAL_TREE_WALK
   void sendNodeInteractionsToGpu(DoubleWalkState *state, TreePiece *tp);
   void sendPartInteractionsToGpu(DoubleWalkState *state, TreePiece *tp);
-  void disableGpu() {bUseGpu = 0;}
 #endif
 
   private:
@@ -201,10 +199,8 @@ class ListCompute : public Compute{
   void addNodeToInt(GenericTreeNode *node, int offsetID, DoubleWalkState *s);
 
   DoubleWalkState *allocDoubleWalkState();
-#ifdef CUDA
   // used to flag cpu for usage when compiling with CUDA enabled
-  int bUseGpu;
-#endif
+  int bUseCpu;
 
 #if defined CHANGA_REFACTOR_PRINT_INTERACTIONS || defined CHANGA_REFACTOR_WALKCHECK_INTERLIST || defined CUDA
   void addRemoteParticlesToInt(ExternalGravityParticle *parts, int n,

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -166,6 +166,7 @@ void DataManager::clearRegisteredPieces(const CkCallback& cb) {
     contribute(cb);
 }
 
+#ifdef CUDA
 // This gets called before a tree build happens and ensures that
 // registeredTreePieces doesnt get cleared during combineLocalTrees
 // if we are about to do a gravity calculation on the GPU
@@ -173,6 +174,7 @@ void DataManager::unmarkTreePiecesForCleanup(const CkCallback& cb) {
     cleanupTreePieces = false;
     contribute(cb);
 }
+#endif
 
 
 /// \brief Build a local tree inside the node.

--- a/DataManager.cpp
+++ b/DataManager.cpp
@@ -213,6 +213,12 @@ void DataManager::combineLocalTrees(CkReductionMsg *msg) {
 
 #ifndef CUDA
     registeredTreePieces.removeAll();
+#else
+    // TODO fix
+    int bUseGpu = 0;
+    if (!bUseGpu) {
+      registeredTreePieces.removeAll();
+    }
 #endif
 
 #ifdef PRINT_MERGED_TREE

--- a/DataManager.h
+++ b/DataManager.h
@@ -77,8 +77,8 @@ protected:
 	/// A list of roots of the TreePieces in this node
 	// holds chare array indices of registered treepieces
 	CkVec<TreePieceDescriptor> registeredTreePieces;
-       // Signal whether registeredTreePieces needs to be cleaned
-       // when combining local trees
+       /// Signal whether registeredTreePieces needs to be cleaned
+       /// when combining local trees
        bool cleanupTreePieces;
 #ifdef CUDA
 	//CkVec<int> registeredTreePieceIndices;

--- a/DataManager.h
+++ b/DataManager.h
@@ -77,6 +77,9 @@ protected:
 	/// A list of roots of the TreePieces in this node
 	// holds chare array indices of registered treepieces
 	CkVec<TreePieceDescriptor> registeredTreePieces;
+       // Signal whether registeredTreePieces needs to be cleaned
+       // when combining local trees
+       bool cleanupTreePieces;
 #ifdef CUDA
 	//CkVec<int> registeredTreePieceIndices;
         /// @brief counter for the number of tree nodes that are
@@ -252,6 +255,7 @@ public:
         std::map<NodeKey, int> &getCachedPartsOnGpuTable(){
           return cachedPartsOnGpu;
         }
+        void unmarkTreePiecesForCleanup(const CkCallback& cb);
 #endif
 	// Functions used to create a tree inside the DataManager comprising
 	// all the trees in the TreePieces in the local node

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -460,7 +460,7 @@ mainmodule ParallelGravity {
 
     entry void startORBTreeBuild(CkReductionMsg* m);
 
-    entry void startGravity(int activeRung, double myTheta, int bUseCpu_, const CkCallback &cb);
+    entry void startGravity(int activeRung, int bUseCpu_, double myTheta, const CkCallback &cb);
 
 #ifdef PUSH_GRAVITY
     entry void startPushGravity(int am, double myTheta);

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -460,11 +460,7 @@ mainmodule ParallelGravity {
 
     entry void startORBTreeBuild(CkReductionMsg* m);
 
-#ifdef CUDA
-    entry void startGravity(int activeRung, double myTheta, int bUseGpu_, const CkCallback &cb);
-#else
-    entry void startGravity(int activeRung, double myTheta, const CkCallback &cb);
-#endif
+    entry void startGravity(int activeRung, double myTheta, int bUseCpu_, const CkCallback &cb);
 
 #ifdef PUSH_GRAVITY
     entry void startPushGravity(int am, double myTheta);

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -250,6 +250,7 @@ mainmodule ParallelGravity {
     entry void startLocalWalk();
     entry void resumeRemoteChunk();
     entry void createStreams(int _numStreams, const CkCallback& cb);
+    entry void unmarkTreePiecesForCleanup(const CkCallback& cb);
 #endif
     entry void initCooling(double dGmPerCcUnit, double dComovingGmPerCcUnit,
 		       double dErgPerGmUnit, double dSecUnit, double dKpcUnit,
@@ -459,7 +460,12 @@ mainmodule ParallelGravity {
 
     entry void startORBTreeBuild(CkReductionMsg* m);
 
+#ifdef CUDA
+    entry void startGravity(int activeRung, double myTheta, int bUseGpu_, const CkCallback &cb);
+#else
     entry void startGravity(int activeRung, double myTheta, const CkCallback &cb);
+#endif
+
 #ifdef PUSH_GRAVITY
     entry void startPushGravity(int am, double myTheta);
     entry void recvPushBuckets(BucketMsg *);

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -1797,7 +1797,7 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
 #ifdef CUDA
                 bUseCpu = nActiveGrav < param.nGpuMinParts;
 #endif
-                treeProxy.startGravity(iActiveRung, bUseCpu, theta, cbGravity);
+                treeProxy.startGravity(iActiveRung, bUseCpu, theta, CkCallbackResumeThread());
 
 #ifdef PUSH_GRAVITY
             }

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -1719,7 +1719,7 @@ void Main::buildTree(int iPhase)
 #ifdef CUDA
     // If we are about to use the GPU, tell the data manager
     // not to clean up its TreePiece list during combineLocalTrees
-    if (nActiveGrav > param.nGpuMinParts) {
+    if (nActiveGrav >= param.nGpuMinParts) {
         dMProxy.unmarkTreePiecesForCleanup(CkCallbackResumeThread());
     }
 #endif
@@ -1774,12 +1774,11 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
             }
             else{
 #endif
-
+		 int bUseCpu = 1;
 #ifdef CUDA
-                treeProxy.startGravity(iActiveRung, theta, nActiveGrav > param.nGpuMinParts, cbGravity);
-#else
-                treeProxy.startGravity(iActiveRung, theta, cbGravity);
+                bUseCpu = nActiveGrav < param.nGpuMinParts;
 #endif
+                treeProxy.startGravity(iActiveRung, theta, bUseCpu, cbGravity);
 
 #ifdef PUSH_GRAVITY
             }
@@ -1794,11 +1793,11 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
             else{
 #endif
 
+		 int bUseCpu = 1;
 #ifdef CUDA
-                treeProxy.startGravity(iActiveRung, theta, nActiveGrav > param.nGpuMinParts, CkCallbackResumeThread());
-#else
-                treeProxy.startGravity(iActiveRung, theta, CkCallbackResumeThread());
+                bUseCpu = nActiveGrav < param.nGpuMinParts;
 #endif
+                treeProxy.startGravity(iActiveRung, theta, bUseCpu, cbGravity);
 
 #ifdef PUSH_GRAVITY
             }

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -759,7 +759,7 @@ Main::Main(CkArgMsg* m) {
                     sizeof(int),"str", "Number of CUDA streams (default: 100)");
         param.nGpuMinParts = 1000;
         prmAddParam(prm, "nGpuMinParts", paramInt, &param.nGpuMinParts,
-                    sizeof(int),"str", "Min particles on rung to trigger GPU (default: 1000)");
+                    sizeof(int),"gpup", "Min particles on rung to trigger GPU (default: 1000)");
 #endif
 	particlesPerChare = 0;
 	prmAddParam(prm, "nPartPerChare", paramInt, &particlesPerChare,
@@ -1762,10 +1762,10 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
         turnProjectionsOn(iActiveRung);
 #endif
 
-        CkPrintf("Calculating gravity (tree bucket, theta = %f) ... ", theta);
 #ifdef CUDA
-        if (nActiveGrav > param.nGpuMinParts) CkPrintf(" on the GPU\n");
+        if (nActiveGrav > param.nGpuMinParts) CkPrintf("Gravity will be calculated on the GPU\n");
 #endif
+        CkPrintf("Calculating gravity (tree bucket, theta = %f) ... ", theta);
         *startTime = CkWallTimer();
         if(param.bConcurrentSph) {
 #ifdef PUSH_GRAVITY

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -757,6 +757,9 @@ Main::Main(CkArgMsg* m) {
         numStreams = 100;
         prmAddParam(prm, "nStreams", paramInt, &numStreams,
                     sizeof(int),"str", "Number of CUDA streams (default: 100)");
+        param.nGpuMinParts = 1000;
+        prmAddParam(prm, "nGpuMinParts", paramInt, &param.nGpuMinParts,
+                    sizeof(int),"str", "Min particles on rung to trigger GPU (default: 1000)");
 #endif
 	particlesPerChare = 0;
 	prmAddParam(prm, "nPartPerChare", paramInt, &particlesPerChare,

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2745,16 +2745,6 @@ Main::initialForces()
   if(verbosity)
       memoryStats();
   
-#ifdef CUDA
-  // TODO fix
-  ckout << "Init. Accel. ...";
-  double dInitAccelTime = CkWallTimer();
-  //treeProxy.initAccel(0, CkCallbackResumeThread());
-  ckout << " took " << (CkWallTimer() - dInitAccelTime) << " seconds."
-        << endl;
-#endif
-
-      
   CkCallback cbGravity(CkCallback::resumeThread);  // needed below to wait for gravity
 
   double gravStartTime;

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -1778,7 +1778,7 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
 #ifdef CUDA
                 bUseCpu = nActiveGrav < param.nGpuMinParts;
 #endif
-                treeProxy.startGravity(iActiveRung, theta, bUseCpu, cbGravity);
+                treeProxy.startGravity(iActiveRung, bUseCpu, theta, cbGravity);
 
 #ifdef PUSH_GRAVITY
             }
@@ -1797,7 +1797,7 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
 #ifdef CUDA
                 bUseCpu = nActiveGrav < param.nGpuMinParts;
 #endif
-                treeProxy.startGravity(iActiveRung, theta, bUseCpu, cbGravity);
+                treeProxy.startGravity(iActiveRung, bUseCpu, theta, cbGravity);
 
 #ifdef PUSH_GRAVITY
             }

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -1798,7 +1798,8 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
 #ifdef CUDA
         // We didn't do gravity where the registered TreePieces on the
         // DataManager normally get cleared.  Clear them here instead.
-        dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
+        // TODO fix
+        //dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
 #endif
         }
 }
@@ -2722,9 +2723,10 @@ Main::initialForces()
       memoryStats();
   
 #ifdef CUDA
+  // TODO fix
   ckout << "Init. Accel. ...";
   double dInitAccelTime = CkWallTimer();
-  treeProxy.initAccel(0, CkCallbackResumeThread());
+  //treeProxy.initAccel(0, CkCallbackResumeThread());
   ckout << " took " << (CkWallTimer() - dInitAccelTime) << " seconds."
         << endl;
 #endif
@@ -3650,9 +3652,10 @@ void Main::writeOutput(int iStep)
 			      CkCallbackResumeThread());
 	treeProxy.finishNodeCache(CkCallbackResumeThread());
 #ifdef CUDA
+        // TODO fix
         // We didn't do gravity where the registered TreePieces on the
         // DataManager normally get cleared.  Clear them here instead.
-        dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
+        //dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
 #endif
 	if(verbosity) {
 	    ckout << " took " << (CkWallTimer() - startTime) << " seconds."
@@ -3691,9 +3694,10 @@ void Main::writeOutput(int iStep)
 				  CkCallbackResumeThread());
 	    treeProxy.finishNodeCache(CkCallbackResumeThread());
 #ifdef CUDA
+            // TODO fix
             // We didn't do gravity where the registered TreePieces on the
             // DataManager normally get cleared.  Clear them here instead.
-            dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
+            //dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
 #endif
 	    if(verbosity)
 		ckout << " took " << (CkWallTimer() - startTime) << " seconds."

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -1774,7 +1774,7 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
             }
             else{
 #endif
-		 int bUseCpu = 1;
+		int bUseCpu = 1;
 #ifdef CUDA
                 bUseCpu = nActiveGrav < param.nGpuMinParts;
 #endif
@@ -1793,7 +1793,7 @@ void Main::startGravity(const CkCallback& cbGravity, int iActiveRung,
             else{
 #endif
 
-		 int bUseCpu = 1;
+		int bUseCpu = 1;
 #ifdef CUDA
                 bUseCpu = nActiveGrav < param.nGpuMinParts;
 #endif

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1413,6 +1413,7 @@ private:
 	/** @brief Start a full step of bucket computation, it sends a message
 	 * to trigger nextBucket() which will loop over all the buckets.
 	 */
+       void schedCpuWalk();
 	void doAllBuckets();
 	void reconstructNodeLookup(GenericTreeNode *node);
 	//void rebuildSFCTree(GenericTreeNode *node,GenericTreeNode *parent,int *);

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1586,6 +1586,7 @@ public:
                          int bComove, double dRhoFac);
 	void BucketEwald(GenericTreeNode *req, int nReps,double fEwCut);
 	void EwaldInit();
+       void ewaldCPU(EwaldMsg *msg);
 	void calculateEwald(EwaldMsg *m);
   void calculateEwaldUsingCkLoop(int yield_num);
   void callBucketEwald(int id);

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -908,7 +908,6 @@ class TreePiece : public CBase_TreePiece {
         size_t sCompactParts;
         size_t sVarParts;
 	cudaStream_t stream;
-        int bUseGpu;
 
         int getNumBuckets(){
         	return numBuckets;
@@ -1201,6 +1200,9 @@ private:
         /// The current active mask for force computation in multistepping
         int activeRung;
 
+	/// Whether the GPU or CPU is to be used on the current substep
+       int bUseCpu;
+
 	/// Periodic Boundary stuff
 	int bPeriodic;
 	int bComove;
@@ -1459,9 +1461,9 @@ public:
 #if INTERLIST_VER > 0
 	  sInterListWalk = NULL;
 #endif
+          bUseCpu = 1;
 #ifdef CUDA
           numActiveBuckets = -1;
-          bUseGpu = 0;
 #ifdef HAPI_TRACE
           localNodeInteractions = 0;
           localPartInteractions = 0;
@@ -1902,13 +1904,9 @@ public:
   /// @brief Start a tree based gravity computation.
   /// @param am the active rung for the computation
   /// @param theta the opening angle
-  /// @param bUseGpu_ whether the gpu is being used
+  /// @param bUseCpu_ whether the cpu or gpu is being used
   /// @param cb the callback to use after all the computation has finished
-#ifdef CUDA
-  void startGravity(int am, double myTheta, int bUseGpu_, const CkCallback& cb);
-#else
-  void startGravity(int am, double myTheta, const CkCallback& cb);
-#endif
+  void startGravity(int am, double myTheta, int bUseCpu_, const CkCallback& cb);
   /// Setup utility function for all the smooths.  Initializes caches.
   void setupSmooth();
   /// Start a tree based smooth computation.

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1901,8 +1901,13 @@ public:
   /// @brief Start a tree based gravity computation.
   /// @param am the active rung for the computation
   /// @param theta the opening angle
+  /// @param bUseGpu_ whether the gpu is being used
   /// @param cb the callback to use after all the computation has finished
+#ifdef CUDA
+  void startGravity(int am, double myTheta, int bUseGpu_, const CkCallback& cb);
+#else
   void startGravity(int am, double myTheta, const CkCallback& cb);
+#endif
   /// Setup utility function for all the smooths.  Initializes caches.
   void setupSmooth();
   /// Start a tree based smooth computation.

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1905,7 +1905,7 @@ public:
   /// @param theta the opening angle
   /// @param bUseCpu_ whether the cpu or gpu is being used
   /// @param cb the callback to use after all the computation has finished
-  void startGravity(int am, double myTheta, int bUseCpu_, const CkCallback& cb);
+  void startGravity(int am, int bUseCpu_, double myTheta, const CkCallback& cb);
   /// Setup utility function for all the smooths.  Initializes caches.
   void setupSmooth();
   /// Start a tree based smooth computation.

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1461,7 +1461,7 @@ public:
 #endif
 #ifdef CUDA
           numActiveBuckets = -1;
-          bUseGpu = 0; // TODO fix
+          bUseGpu = 0;
 #ifdef HAPI_TRACE
           localNodeInteractions = 0;
           localPartInteractions = 0;

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1415,7 +1415,6 @@ private:
 	/** @brief Start a full step of bucket computation, it sends a message
 	 * to trigger nextBucket() which will loop over all the buckets.
 	 */
-       void schedCpuWalk();
 	void doAllBuckets();
 	void reconstructNodeLookup(GenericTreeNode *node);
 	//void rebuildSFCTree(GenericTreeNode *node,GenericTreeNode *parent,int *);

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -908,6 +908,7 @@ class TreePiece : public CBase_TreePiece {
         size_t sCompactParts;
         size_t sVarParts;
 	cudaStream_t stream;
+        int bUseGpu;
 
         int getNumBuckets(){
         	return numBuckets;
@@ -1459,6 +1460,7 @@ public:
 #endif
 #ifdef CUDA
           numActiveBuckets = -1;
+          bUseGpu = 0; // TODO fix
 #ifdef HAPI_TRACE
           localNodeInteractions = 0;
           localPartInteractions = 0;

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1200,7 +1200,7 @@ private:
         /// The current active mask for force computation in multistepping
         int activeRung;
 
-	/// Whether the GPU or CPU is to be used on the current substep
+	/// Whether the GPU or CPU is to be used on the current gravity substep
        int bUseCpu;
 
 	/// Periodic Boundary stuff

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3761,7 +3761,7 @@ void TreePiece::finishBucket(int iBucket) {
       // confused.
       if (bUseGpu) {
         dm->transferParticleVarsBack();
-        bUseGpu = 0; // TODO fixme is this a good place to reset this?
+        bUseGpu = 0;
       } else {
         continueWrapUp();
       }

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -4955,8 +4955,8 @@ void TreePiece::recvTotalMass(CkReductionMsg *msg){
 /// then starts the Ewald initialization, and finally starts the local
 /// gravity walk.
 void TreePiece::startGravity(int am, // the active mask for multistepping
-			       double myTheta, // opening criterion
                                int bUseCpu_, // whether the cpu or gpu will be used
+			       double myTheta, // opening criterion
 			       const CkCallback& cb) {
   bUseCpu = bUseCpu_;
 

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3761,6 +3761,7 @@ void TreePiece::finishBucket(int iBucket) {
       // confused.
       if (bUseGpu) {
         dm->transferParticleVarsBack();
+        bUseGpu = 0; // TODO fixme is this a good place to reset this?
       } else {
         continueWrapUp();
       }
@@ -4968,10 +4969,18 @@ void TreePiece::recvTotalMass(CkReductionMsg *msg){
 /// eventually call a remote walk (a walk on non-local nodes).  It
 /// then starts the Ewald initialization, and finally starts the local
 /// gravity walk.
-
+#ifdef CUDA
+void TreePiece::startGravity(int am, // the active mask for multistepping
+			       double myTheta, // opening criterion
+                               int bUseGpu_, // whether the gpu will be used
+			       const CkCallback& cb) {
+  bUseGpu = bUseGpu_;
+#else
 void TreePiece::startGravity(int am, // the active mask for multistepping
 			       double myTheta, // opening criterion
 			       const CkCallback& cb) {
+#endif
+
   double starttime;
   LBTurnInstrumentOn();
   iterationNo++;

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3748,9 +3748,7 @@ void TreePiece::finishBucket(int iBucket) {
 #endif
       }
 
-#if defined CUDA
       if (bUseCpu)
-#endif
       {
         continueWrapUp();
       }
@@ -4153,9 +4151,7 @@ void TreePiece::ewaldCPU(EwaldMsg *msg) {
 /// @brief Start the ewald calculation on this TreePiece
 /// @param msg Indicates whether this function was called from EwaldInit
 void TreePiece::calculateEwald(EwaldMsg *msg) {
-#ifdef SPCUDA
   if (bUseCpu)
-#endif
   {
       ewaldCPU(msg);
   }

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3888,7 +3888,6 @@ void TreePiece::doAllBuckets(){
 #ifdef GPU_LOCAL_TREE_WALK
   else {
     ListCompute *listcompute = (ListCompute *) sGravity;
-    listcompute->enableCpu();
     DoubleWalkState *state = (DoubleWalkState *)sLocalGravityState;
 
     listcompute->sendLocalTreeWalkTriggerToGpu(state, this, activeRung, 0, numBuckets);

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3975,7 +3975,6 @@ void TreePiece::nextBucket(dummyMsg *msg){
       CkAssert(currentBucket >= startBucket);
 
 #if !defined(CUDA)
-      // TODO fix
       if (useckloop) {
         lpdata->lowNodes.insertAtEnd(lowestNode);
         lpdata->bucketids.insertAtEnd(currentBucket);
@@ -4063,7 +4062,6 @@ void TreePiece::nextBucket(dummyMsg *msg){
   }// end while
 
 #if INTERLIST_VER > 0 && !defined(CUDA)
-  // TODO fix
   if (useckloop) {
     // Use ckloop to parallelize force calculation and this will update the
     // counterArrays as well.
@@ -4281,7 +4279,6 @@ void TreePiece::calculateGravityRemote(ComputeChunkMsg *msg) {
 
 #if INTERLIST_VER > 0
 #if !defined(CUDA)
-  // TODO fix
   LoopParData* lpdata;
   // Keep track of which was the currentBucket so that it can be restored in the
   // ckloop part.
@@ -4408,7 +4405,6 @@ void TreePiece::calculateGravityRemote(ComputeChunkMsg *msg) {
       // When using ckloop to parallelize force calculation, first the list is
       // populated with nodes and particles with which the force is calculated.
 #if !defined(CUDA)
-      // TODO fix
       if (useckloop) {
         lpdata->lowNodes.insertAtEnd(lowestNode);
         lpdata->bucketids.insertAtEnd(sRemoteGravityState->currentBucket);
@@ -4477,7 +4473,6 @@ void TreePiece::calculateGravityRemote(ComputeChunkMsg *msg) {
 
 
 #if INTERLIST_VER > 0 && !defined(CUDA)
-  // TODO fix
   if (useckloop) {
     // Now call ckloop parallelization function which will execute the force
     // calculation in parallel and update the counterArrays.

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -4138,18 +4138,7 @@ void TreePiece::calculateGravityLocal() {
   doAllBuckets();
 }
 
-/// @brief Start the ewald calculation on this TreePiece
-/// @param msg Indicates whether this function was called from EwaldInit
-void TreePiece::calculateEwald(EwaldMsg *msg) {
-#ifdef SPCUDA
-  if (bUseGpu) {
-    if(!msg->fromInit){
-      thisProxy[thisIndex].EwaldGPU();
-    }
-    delete msg;
-  }
-#else
-
+void TreePiece::ewaldCPU(EwaldMsg *msg) {
   bool useckloop = false;
   int yield_num = _yieldPeriod;
 
@@ -4179,6 +4168,24 @@ void TreePiece::calculateEwald(EwaldMsg *msg) {
   } else {
     delete msg;
   }
+}
+
+/// @brief Start the ewald calculation on this TreePiece
+/// @param msg Indicates whether this function was called from EwaldInit
+void TreePiece::calculateEwald(EwaldMsg *msg) {
+#ifdef SPCUDA
+  if (bUseGpu) {
+    if(!msg->fromInit){
+      thisProxy[thisIndex].EwaldGPU();
+    }
+    delete msg;
+  } else {
+      ewaldCPU(msg);
+  }
+#else
+
+  ewalcCpu(msg);
+
 #endif
 }
 

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -4167,7 +4167,7 @@ void TreePiece::calculateEwald(EwaldMsg *msg) {
   }
 #else
 
-  ewalcCpu(msg);
+  ewaldCPU(msg);
 
 #endif
 }

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3867,7 +3867,7 @@ void TreePiece::continueWrapUp(){
   }
 }
 
-// Schedule a walk on the CPU
+/// Schedule a walk on the CPU
 void TreePiece::schedCpuWalk(){
     dummyMsg *msg = new (8*sizeof(int)) dummyMsg;
     *((int *)CkPriorityPtr(msg)) = 2 * numTreePieces * numChunks + thisIndex + 1;

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -3926,22 +3926,7 @@ void TreePiece::nextBucket(dummyMsg *msg){
   int yield_num = _yieldPeriod;
 #if INTERLIST_VER > 0
 
-#ifdef CUDA
-  // TODO fix repeated code
-  if (!bUseGpu) {
-    LoopParData* lpdata;
-    int tmpBucketBegin;
-    if (bUseCkLoopPar && otherIdlePesAvail()) {
-      useckloop = true;
-      // This value was chosen to be 2*Nodesize so that we have enough buckets for
-      // all the PEs in the node and also giving some extra for load balance.
-      yield_num = 2 * CkMyNodeSize();
-      lpdata = new LoopParData();
-      lpdata->tp = this;
-      tmpBucketBegin = currentBucket;
-    }
-  }
-#else
+#ifndef CUDA
   LoopParData* lpdata;
   int tmpBucketBegin;
   if (bUseCkLoopPar && otherIdlePesAvail()) {

--- a/feedback.cpp
+++ b/feedback.cpp
@@ -323,7 +323,9 @@ void Main::StellarFeedback(double dTime, double dDelta)
 #ifdef CUDA
         // We didn't do gravity where the registered TreePieces on the
         // DataManager normally get cleared.  Clear them here instead.
-        dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
+        if (nActiveGrav > param.nGpuMinParts) {
+            dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
+        }
 #endif
 
 #ifdef SPLITGAS

--- a/parameters.h
+++ b/parameters.h
@@ -31,6 +31,9 @@ typedef struct parameters {
     double dEta;
     int nTruncateRung;
     int iMaxRung;
+#ifdef CUDA
+    int nGpuMinParts;
+#endif
     int bCannonical;
     int bKDK;
     int bDtAdjust;
@@ -176,6 +179,9 @@ inline void operator|(PUP::er &p, Parameters &param) {
     p|param.bGravStep;
     p|param.dEta;
     p|param.nTruncateRung;
+#ifdef CUDA
+    p|param.nGpuMinParts;
+#endif
     p|param.iMaxRung;
     p|param.bCannonical;
     p|param.bKDK;

--- a/starform.cpp
+++ b/starform.cpp
@@ -189,7 +189,9 @@ void Main::FormStars(double dTime, double dDelta)
 #ifdef CUDA
     // We didn't do gravity where the registered TreePieces on the
     // DataManager normally get cleared.  Clear them here instead.
-    dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
+    if (nActiveGrav > param.nGpuMinParts) {
+        dMProxy.clearRegisteredPieces(CkCallbackResumeThread());
+    }
 #endif
 
     addDelParticles();


### PR DESCRIPTION
Although calculating gravity on the GPU is generally much faster, doing so introduces a significant amount of extra overhead. When using multistepping, it's often the case that using the GPU for gravity on higher rungs actually slows things down.

This PR introduces a new parameter 'nGpuMinParts', which triggers a tree walk on the CPU (instead of the GPU) whenever the number of active particles falls below the threshold.