### PR TITLE
Github workflows: change source of charm distribution.

### DIFF
--- a/.github/workflows/changa-smp.yml
+++ b/.github/workflows/changa-smp.yml
@@ -11,17 +11,16 @@ jobs:
     - name: build-charm++
       run: |
         export CHARM_VERSION=7.0.0
-        wget http://charm.cs.illinois.edu/distrib/charm-$CHARM_VERSION.tar.gz
-        tar -xzf charm-$CHARM_VERSION.tar.gz
-        cd charm-v$CHARM_VERSION
+        git clone https://github.com/charmplusplus/charm.git
+        cd charm
+        git checkout v$CHARM_VERSION
         ./build ChaNGa netlrts-linux-x86_64 smp --with-production --enable-error-checking -j4
         cd ..
     - name: build-changa
       run: |
-        export CHARM_VERSION=7.0.0
         git clone https://github.com/N-bodyshop/utility
         export STRUCT_DIR=$PWD/utility/structures
-        export CHARM_DIR=$PWD/charm-v$CHARM_VERSION
+        export CHARM_DIR=$PWD/charm
         ./configure
         make -j4
     - name: test-changa

--- a/.github/workflows/changa.yml
+++ b/.github/workflows/changa.yml
@@ -11,9 +11,9 @@ jobs:
     - name: build-charm++
       run: |
         export CHARM_VERSION=7.0.0
-        wget http://charm.cs.illinois.edu/distrib/charm-$CHARM_VERSION.tar.gz
-        tar -xzf charm-$CHARM_VERSION.tar.gz
-        cd charm-v$CHARM_VERSION
+        git clone https://github.com/charmplusplus/charm.git
+        cd charm
+        git checkout v$CHARM_VERSION
         ./build ChaNGa netlrts-linux-x86_64 --with-production --enable-error-checking -j4
         cd ..
     - name: build-changa
@@ -21,7 +21,7 @@ jobs:
         export CHARM_VERSION=7.0.0
         git clone https://github.com/N-bodyshop/utility
         export STRUCT_DIR=$PWD/utility/structures
-        export CHARM_DIR=$PWD/charm-v$CHARM_VERSION
+        export CHARM_DIR=$PWD/charm
         ./configure
         make -j4
     - name: test-changa


### PR DESCRIPTION
This changes the CI to use github clones to grab the charm distribution.