### PR TITLE
massMetalsEnergyCheck(): correctly account SUPERBUBBLE energy

### DIFF
--- a/feedback.cpp
+++ b/feedback.cpp
@@ -1070,9 +1070,8 @@ TreePiece::massMetalsEnergyCheck(int bPreDist, const CkCallback& cb)
 	    dTotals[3] += p->mass*p->fMFracIron();
 #ifdef SUPERBUBBLE
 	    dTotals[4] += p->massHot()*p->fESNrate();
-#else
-	    dTotals[4] += p->mass*p->fESNrate();
 #endif
+	    dTotals[4] += p->mass*p->fESNrate();
 	    }
 	if(p->isStar()) {
 	    dTotals[1] += p->mass*p->fStarMetals();


### PR DESCRIPTION
Energy is put into either hot or cold phase, so account for both when checking on the energy
conservation.