### PR TITLE
Remove -m64 from target_arch

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,7 +43,7 @@ charmrun    := charmrun
 cxx_std     := c++11
 c_std       := c99
 opt_flag    := -O3
-target_arch := -m64
+target_arch :=
 threads     := -lpthread
 
 # ------- Debugging -----------------------------------------------------------


### PR DESCRIPTION
This breaks on ARM compiles, and it is not clear if it is ever needed on x86 architectures: all available x86 architectures are 64 bit by default.
