### PR TITLE
Cleanup uninitialized memory problem in Stfm.

### DIFF
--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -2572,6 +2572,8 @@ void Main::setupICs() {
       if(param.sinks.bBHSink)
 	  param.sinks.dDeltaStarForm = param.stfm->dDeltaStarForm;
       }
+  else
+      param.stfm->NullStarForm();
   if(param.bStarForm || param.bFeedback || param.iSIDMSelect) {
       treeProxy.initRand(param.iRandomSeed, CkCallbackResumeThread());
   }

--- a/starform.h
+++ b/starform.h
@@ -57,6 +57,7 @@ class Stfm {
     double dDeltaStarForm;	/* timestep in system units */
     void AddParams(PRM prm);
     void CheckParams(PRM prm, struct parameters &param);
+    void NullStarForm() { imf = new Kroupa01(); } /* Place holder */
     bool isStarFormRung(int aRung) {return aRung <= iStarFormRung;}
     GravityParticle *FormStar(GravityParticle *p,  COOL *Cool, double dTime,
 			      double dDelta, double dCosmoFac, double *T, double *H2Fraction, LWDATA *LWData, Rand& rndGen);


### PR DESCRIPTION
The stochastic star formation code introduced an uninitialized memory problem that sometimes caused checkpoints to fail.
This also caused problems with some github CI runs.