### PR TITLE
Simplified "deep copy" constructors needed for the IMF pointer.

### DIFF
--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -127,7 +127,6 @@ mainmodule ParallelGravity {
   PUPable SinkAccreteTestSmoothParams;
   PUPable SinkingAverageSmoothParams;
   PUPable SinkAccreteSmoothParams;
-  PUPable Fdbk;
   PUPable StarLog;
   PUPable Chabrier;
   PUPable MillerScalo;

--- a/feedback.h
+++ b/feedback.h
@@ -59,17 +59,8 @@ class SFEvent {
     };
 
 /// @brief Stellar/Supernova feedback parameters and routines.
-class Fdbk : public PUP::able {
- private:
-    Fdbk& operator=(const Fdbk& fb);
-    void CalcWindFeedback(SFEvent *sfEvent, double dTime, 
-                          double dDelta, FBEffects *fbEffects) const;
-    void CalcUVFeedback(SFEvent *sfEvent, double dTime, double dDelta,
-                        FBEffects *fbEffects) const;
-#ifdef COOLING_MOLECULARH
-    double CalcLWFeedback(SFEvent *sfEvent, double dTime, double dDelta, LWDATA *LWData) const;
-#endif /*COOLING_MOLECULARH*/
-
+class Fdbk_Shallow {
+ protected:
     double dGmUnit;		/* system mass in grams */
     double dGmPerCcUnit;	/* system density in gm/cc */
     double dErgUnit;		/* system energy in ergs */
@@ -98,64 +89,52 @@ class Fdbk : public PUP::able {
     double dMultiPhaseMinTemp;
     double dMultiPhaseMaxTime;
     double dEarlyETotal;  /* Total E in early FB per solar mass of stars */
-    IMF *imf;
+    };
 
+/// @ brief Derived class to handle the deep copy for the IMF pointer.
+/// N.B.  All attributes except imf need to be in Fdbk_Shallow.
+class Fdbk : public Fdbk_Shallow {
+private:
+    Fdbk& operator=(const Fdbk& fb); /* private to prevent use */
+    void CalcWindFeedback(SFEvent *sfEvent, double dTime, 
+                          double dDelta, FBEffects *fbEffects) const;
+    void CalcUVFeedback(SFEvent *sfEvent, double dTime, double dDelta,
+                        FBEffects *fbEffects) const;
+#ifdef COOLING_MOLECULARH
+    double CalcLWFeedback(SFEvent *sfEvent, double dTime, double dDelta, LWDATA *LWData) const;
+#endif /*COOLING_MOLECULARH*/
+
+public:
+    IMF *imf;
     void AddParams(PRM prm);
     void CheckParams(PRM prm, struct parameters &param);
     void NullFeedback() { imf = new Kroupa01(); } /* Place holder */
     void DoFeedback(GravityParticle *p, double dTime, double dDeltaYr, 
                     FBEffects *fbTotals, LWDATA *LWData, Rand& rndGen) const;
     double NSNIa (double dMassT1, double dMassT2);
-    Fdbk() { }
 
-    PUPable_decl(Fdbk);
+    Fdbk() { }
     Fdbk(const Fdbk& fb);
-    Fdbk(CkMigrateMessage *m) : PUP::able(m) {}
     ~Fdbk() {
 	delete imf;
 	}
     inline void pup(PUP::er &p);
-    };
-
+};
+    
 //  "Deep copy" constructer is need because of imf pointer.
-inline Fdbk::Fdbk(const Fdbk& fb) {
-    strcpy(achIMF, fb.achIMF);
-    dDeltaStarForm = fb.dDeltaStarForm;
-    dErgPerGmUnit = fb.dErgPerGmUnit;
-    dGmUnit = fb.dGmUnit;
-    dGmPerCcUnit = fb.dGmPerCcUnit;
-    dErgUnit = fb.dErgUnit;
-    dSecUnit = fb.dSecUnit;
-    dMaxGasMass = fb.dMaxGasMass;
-#ifdef SPLITGAS
-    dInitGasMass = fb.dInitGasMass;
-#endif
-    bSNTurnOffCooling = fb.bSNTurnOffCooling;
-    bSmallSNSmooth = fb.bSmallSNSmooth;
-    bShortCoolShutoff = fb.bShortCoolShutoff;
-    bAGORAFeedback = fb.bAGORAFeedback;
-    dExtraCoolShutoff = fb.dExtraCoolShutoff;
-    dRadPreFactor = fb.dRadPreFactor;
-    dTimePreFactor = fb.dTimePreFactor;
-    nSmoothFeedback = fb.nSmoothFeedback;
-    dMaxCoolShutoff = fb.dMaxCoolShutoff;
-    dEarlyFeedbackFrac = fb.dEarlyFeedbackFrac;
-    dFBInitialMassLoad = fb.dFBInitialMassLoad;
-    dMultiPhaseMinTemp = fb.dMultiPhaseMinTemp;
-    dMultiPhaseMaxTime = fb.dMultiPhaseMaxTime;
-    dEarlyETotal = fb.dEarlyETotal;
-    sn = fb.sn;
-    pdva = fb.pdva;
+inline Fdbk::Fdbk(const Fdbk& fb) : Fdbk_Shallow(fb) {
     imf = fb.imf->clone();
 }
 
 inline void Fdbk::pup(PUP::er &p) {
-    p(achIMF, 32);
-    p | dDeltaStarForm;
-    p | dErgPerGmUnit;
     p | dGmUnit;
     p | dGmPerCcUnit;
     p | dErgUnit;
+    p | pdva;
+    p(achIMF, 32);
+    p | sn;
+    p | dDeltaStarForm;
+    p | dErgPerGmUnit;
     p | dSecUnit;
     p | dMaxGasMass;
 #ifdef SPLITGAS
@@ -175,8 +154,6 @@ inline void Fdbk::pup(PUP::er &p) {
     p | dMultiPhaseMinTemp;
     p | dMultiPhaseMaxTime;
     p | dEarlyETotal;
-    p | sn;
-    p | pdva;
     p | imf;
     }
 

--- a/feedback.h
+++ b/feedback.h
@@ -120,7 +120,7 @@ public:
 	}
     inline void pup(PUP::er &p);
 };
-    
+
 //  "Deep copy" constructer is need because of imf pointer.
 inline Fdbk::Fdbk(const Fdbk& fb) : Fdbk_Shallow(fb) {
     imf = fb.imf->clone();

--- a/parameters.h
+++ b/parameters.h
@@ -261,7 +261,9 @@ inline void operator|(PUP::er &p, Parameters &param) {
  	param.stfm = new Stfm();
     p|*param.stfm;
     p|param.bFeedback;
-    p|param.feedback;
+    if(p.isUnpacking())
+        param.feedback = new Fdbk();
+    p|*param.feedback;
     p|param.dThermalCondCoeff;
     p|param.dThermalCondSatCoeff;
     p|param.dThermalCond2Coeff;

--- a/starform.h
+++ b/starform.h
@@ -16,9 +16,8 @@
 #include "lymanwerner.h"
 
 /// Parameters and methods to implement star formation.
-class Stfm {
- private:
-    Stfm& operator=(const Stfm& st);
+class Stfm_Shallow {
+ protected:
     double dGmUnit;		/* system mass in grams */
     double dMsolUnit;    /* system mass unit in Msol */
     double dGmPerCcUnit;	/* system density in gm/cc */
@@ -55,60 +54,39 @@ class Stfm {
     double dMinGasMass;		/* minimum mass gas before we delete
 				   the particle. */
     double dDeltaStarForm;	/* timestep in system units */
+    };
+
+/// @ brief Derived class to handle the deep copy for the IMF pointer.
+/// N.B.  All attributes except imf need to be in Stfm_Shallow.
+class Stfm : public Stfm_Shallow {
+private:
+    Stfm& operator=(const Stfm& st); /* private to prevent use */
+public:
+    IMF *imf;
     void AddParams(PRM prm);
     void CheckParams(PRM prm, struct parameters &param);
     void NullStarForm() { imf = new Kroupa01(); } /* Place holder */
     bool isStarFormRung(int aRung) {return aRung <= iStarFormRung;}
     GravityParticle *FormStar(GravityParticle *p,  COOL *Cool, double dTime,
-			      double dDelta, double dCosmoFac, double *T, double *H2Fraction, LWDATA *LWData, Rand& rndGen);
-    IMF *imf;
+			      double dDelta, double dCosmoFac, double *T,
+                              double *H2Fraction, LWDATA *LWData, Rand& rndGen);
 
     Stfm() {};
     Stfm(const Stfm& st);
     ~Stfm() {
         delete imf;
-    }
-    inline void pup(PUP::er &p);
     };
+    inline void pup(PUP::er &p);
+};
 
 // "Deep copy" constructer is needed because of imf pointer
-inline Stfm::Stfm(const Stfm& st) {
-    dMsolUnit = st.dMsolUnit;
-    dGmUnit = st.dGmUnit;
-    dGmPerCcUnit = st.dGmPerCcUnit;
-    dSecUnit = st.dSecUnit;
-    dErgUnit = st.dErgUnit;
-    dPhysDenMin = st.dPhysDenMin;
-    dOverDenMin = st.dOverDenMin;
-    dTempMax = st.dTempMax;
-    dSoftMin = st.dSoftMin;
-    dCStar = st.dCStar;
-    dStarEff = st.dStarEff;
-    dInitStarMass = st.dInitStarMass;
-    dMinSpawnStarMass = st.dMinSpawnStarMass;
-    dMaxStarMass = st.dMaxStarMass;
-    bGasCooling = st.bGasCooling;
-    bUseStoch = st.bUseStoch;
-    dStochCut = st.dStochCut;
-    iStarFormRung = st.iStarFormRung;
-    dMinGasMass = st.dMinGasMass;
-    dDeltaStarForm = st.dDeltaStarForm;
-#ifdef COOLING_MOLECULARH
-    dStarFormEfficiencyH2 = st.dStarFormEfficiencyH2;
-#endif
-    bBHForm = st.bBHForm;
-    dBHFormProb = st.dBHFormProb;
-    dInitBHMass = st.dInitBHMass;
+inline Stfm::Stfm(const Stfm& st) : Stfm_Shallow(st) {
     imf = st.imf->clone();
 }
 
 inline void Stfm::pup(PUP::er &p) {
-    p|bUseStoch;
-    p|dStochCut;
-    p|dDeltaStarForm;
-    p|iStarFormRung;
-    p|dMsolUnit;
     p|dGmUnit;
+    p|dMsolUnit;
     p|dGmPerCcUnit;
     p|dSecUnit;
     p|dErgUnit;
@@ -120,7 +98,6 @@ inline void Stfm::pup(PUP::er &p) {
     p|dStarEff;
     p|dInitStarMass;
     p|dMinSpawnStarMass;
-    p|dMinGasMass;
     p|dMaxStarMass;
     p|bGasCooling;
 #ifdef COOLING_MOLECULARH
@@ -133,6 +110,11 @@ inline void Stfm::pup(PUP::er &p) {
     p|bBHForm;
     p|dBHFormProb;
     p|dInitBHMass;
+    p|bUseStoch;
+    p|dStochCut;
+    p|iStarFormRung;
+    p|dMinGasMass;
+    p|dDeltaStarForm;
     p|imf;
     }
 


### PR DESCRIPTION
The Fdbk and Stfm classes have a lot of attributes for feedback and star formation, and they need to do a "deep copy" because of the IMF pointer.  It is too easy to forget to add a new parameter to the copy constructor resulting in uninitialized attributes in the class.  This was the root cause of a weird star formation history after a recent merge of star formation code with a downstream branch.

This is a rewrite so that the default constructor is used for the attributes, and only the IMF pointer gets the special constructor.

Note that the "pup" operators have a similar problem.  We should also think about rewriting those.