### PR TITLE
Fixes for chemeq integrator

### DIFF
--- a/cooling_metal.c
+++ b/cooling_metal.c
@@ -2109,10 +2109,6 @@ void clIntegrateEnergy(COOL *cl, clDerivsData *clData, PERBARYON *Y, double *E,
      ymin[2] = YHeMIN;
      ymin[3] = YHeMIN;
 
-      YTotal = (d->Y_H) + (d->Y_H - ymin[1]) + d->Y_He + ymin[3] +
-	2.0*(d->Y_He - ymin[2] - ymin[3]) + d->ZMetal/MU_METAL;
-      EMin = clThermalEnergy( YTotal, cl->TMin );
-      ymin[0] = EMin;
       StiffSetYMin(sbs, ymin);
       
       StiffStep( sbs, y, t, tStep);

--- a/cooling_metal.c
+++ b/cooling_metal.c
@@ -2105,6 +2105,7 @@ void clIntegrateEnergy(COOL *cl, clDerivsData *clData, PERBARYON *Y, double *E,
 
  {
      double ymin[array_length];
+     ymin[0] = EMin;
      ymin[1] = YHMIN;
      ymin[2] = YHeMIN;
      ymin[3] = YHeMIN;
@@ -2112,36 +2113,50 @@ void clIntegrateEnergy(COOL *cl, clDerivsData *clData, PERBARYON *Y, double *E,
       StiffSetYMin(sbs, ymin);
       
       StiffStep( sbs, y, t, tStep);
-      if(y[1] > d->Y_H) y[1] = d->Y_H;
-      if(y[2] > d->Y_He) y[2] = d->Y_He;
-      if(y[3] > d->Y_He) y[3] = d->Y_He;
-      if (fabs(y[2])+fabs(y[3]) > d->Y_He) {
-	  if(y[2] > y[3]) y[3] = d->Y_He - y[2]; 
-	  else y[2] = d->Y_He - y[3]; 
-	  } 
 
-      if(y[1] < YHMIN) y[1] = YHMIN;
-      if(y[2] < YHeMIN) {
-	y[2] = YHeMIN;
-	if (d->Y_He - y[2] - y[3] < YHeMIN) y[3] = d->Y_He - y[2] - YHeMIN;
+      // If the integrator went off the bottom temperature edge of the table, clamp to minimum
+      // energy and calculate current abundances using clAbunds
+      if (y[0] < EMin) {
+        clAbunds( d->cl, &Y, &d->Rate, d->rho, d->ZMetal);
+	y[0] = EMin;
+	y[1] = Y->HI;
+	y[2] = Y->HeI;
+	y[3] = Y->HeII;
       }
-      if(y[3] < YHeMIN) {
-	y[3] = YHeMIN;
-	if (d->Y_He - y[2] - y[3] < YHeMIN) y[2] = d->Y_He - y[3] - YHeMIN;
-      }
+      // Otherwise, use the integrator result and ensure abundances aren't too large or small
+      // Also ensure we havent fallen off the bottom of the table after updating abundances
+      else {
+	if(y[1] > d->Y_H) y[1] = d->Y_H;
+	if(y[2] > d->Y_He) y[2] = d->Y_He;
+	if(y[3] > d->Y_He) y[3] = d->Y_He;
+	if (fabs(y[2])+fabs(y[3]) > d->Y_He) {
+	    if(y[2] > y[3]) y[3] = d->Y_He - y[2];
+	    else y[2] = d->Y_He - y[3];
+	    }
 
-      YTotal = (d->Y_H) + (d->Y_H - y[1]) + d->Y_He + y[3] +
-	2.0*(d->Y_He - y[2] - y[3]) + d->ZMetal/MU_METAL;
-      EMin = clThermalEnergy( YTotal, cl->TMin );
+	if(y[1] < YHMIN) y[1] = YHMIN;
+	if(y[2] < YHeMIN) {
+	  y[2] = YHeMIN;
+	  if (d->Y_He - y[2] - y[3] < YHeMIN) y[3] = d->Y_He - y[2] - YHeMIN;
+	}
+	if(y[3] < YHeMIN) {
+	  y[3] = YHeMIN;
+	  if (d->Y_He - y[2] - y[3] < YHeMIN) y[2] = d->Y_He - y[3] - YHeMIN;
+	}
+
+	YTotal = (d->Y_H) + (d->Y_H - y[1]) + d->Y_He + y[3] +
+	  2.0*(d->Y_He - y[2] - y[3]) + d->ZMetal/MU_METAL;
+	EMin = clThermalEnergy( YTotal, cl->TMin );
 
 
 #ifdef ASSERTENEG      
-      assert(*y > 0.0);
+	assert(*y > 0.0);
 #else
-      if (y[0] < EMin) {
-	y[0] = EMin;
-      }
+	if (y[0] < EMin) {
+	  y[0] = EMin;
+	}
 #endif   
+   }
    cl->its = 1;
    }
 

--- a/cooling_metal_H2.c
+++ b/cooling_metal_H2.c
@@ -2937,6 +2937,7 @@ void clIntegrateEnergy(COOL *cl, clDerivsData *clData, PERBARYON *Y, double *E,
 
  {
      double ymin[array_length];
+     ymin[0] = EMin;
      ymin[1] = YHMIN;
      ymin[2] = YHeMIN;
      ymin[3] = YHeMIN;
@@ -2962,67 +2963,81 @@ void clIntegrateEnergy(COOL *cl, clDerivsData *clData, PERBARYON *Y, double *E,
       }
       /*#endif*/
 
-      if(y[1] > d->Y_H) y[1] = d->Y_H;
-      if(y[4] > d->Y_H/2.0) y[4] = d->Y_H/2.0;
-      if(y[2] > d->Y_He) y[2] = d->Y_He;
-      if(y[3] > d->Y_He) y[3] = d->Y_He;
-      if (fabs(y[2])+fabs(y[3]) > d->Y_He) {
-	  if(y[2] > y[3]) y[3] = d->Y_He - y[2]; 
-	  else y[2] = d->Y_He - y[3]; 
-	  } 
-
-      if (fabs(y[1])+fabs(y[4]*2.0) > d->Y_H) { 
-        if(y[1] > y[4]*2) y[4] = (d->Y_H - y[1])/2.0; 
-          else y[1] = d->Y_H - y[4]*2.0; 
+      // If the integrator went off the bottom temperature edge of the table, clamp to minimum
+      // energy and calculate current abundances using clAbunds
+      if (y[0] < EMin) {
+        clAbunds( d->cl, Y, &d->Rate, d->rho, d->ZMetal);
+        y[0] = EMin;
+        y[1] = Y->HI;
+        y[2] = Y->HeI;
+        y[3] = Y->HeII;
+	y[4] = Y->HII;
       }
+      // Otherwise, use the integrator result and ensure abundances aren't too large or small
+      // Also ensure we havent fallen off the bottom of the table after updating abundances
+      else {
+	if(y[1] > d->Y_H) y[1] = d->Y_H;
+	if(y[4] > d->Y_H/2.0) y[4] = d->Y_H/2.0;
+	if(y[2] > d->Y_He) y[2] = d->Y_He;
+	if(y[3] > d->Y_He) y[3] = d->Y_He;
+	if (fabs(y[2])+fabs(y[3]) > d->Y_He) {
+	    if(y[2] > y[3]) y[3] = d->Y_He - y[2]; 
+	    else y[2] = d->Y_He - y[3]; 
+	    } 
 
-      if(y[4] < YH2MIN) y[4] = YH2MIN;
-      if(y[1] < YHMIN) y[1] = YHMIN;
-      if (d->Y_H - y[1] - 2.0*y[4] < YHMIN) {
-        if (y[1] >= 2.0*y[4]) y[1] = d->Y_H - 2.0*y[4] - YHMIN;
-        else                  y[4] =(d->Y_H - y[1] - YHMIN)/2.0;
+	if (fabs(y[1])+fabs(y[4]*2.0) > d->Y_H) { 
+	  if(y[1] > y[4]*2) y[4] = (d->Y_H - y[1])/2.0; 
+	    else y[1] = d->Y_H - y[4]*2.0; 
+	}
 
-      }
-/*    if(y[4] < YH2MIN) {
-	y[4] = YH2MIN;
-	if (d->Y_H - y[1] - 2.0*y[4] < YHMIN) y[4] = (d->Y_H - y[1] - YHMIN)/2.0;
-      }
-      if(y[1] < YHMIN) {
-	y[1] = YHMIN;
-	if (d->Y_H - y[1] - 2.0*y[4] < YHMIN) y[1] = d->Y_H - 2.0*y[4] - YHMIN;
-	}*/
+	if(y[4] < YH2MIN) y[4] = YH2MIN;
+	if(y[1] < YHMIN) y[1] = YHMIN;
+	if (d->Y_H - y[1] - 2.0*y[4] < YHMIN) {
+	  if (y[1] >= 2.0*y[4]) y[1] = d->Y_H - 2.0*y[4] - YHMIN;
+	  else                  y[4] =(d->Y_H - y[1] - YHMIN)/2.0;
 
-      if(y[2] < YHeMIN) y[2] = YHeMIN;
-      if(y[3] < YHeMIN) y[3] = YHeMIN;
-      if (d->Y_He - y[2] - y[3] < YHeMIN) {
-        if (y[2] >= y[3]) y[2] = d->Y_He - y[3] - YHeMIN;
-        else              y[3] = d->Y_He - y[2] - YHeMIN; 
-      }
+	}
+  /*    if(y[4] < YH2MIN) {
+	  y[4] = YH2MIN;
+	  if (d->Y_H - y[1] - 2.0*y[4] < YHMIN) y[4] = (d->Y_H - y[1] - YHMIN)/2.0;
+	}
+	if(y[1] < YHMIN) {
+	  y[1] = YHMIN;
+	  if (d->Y_H - y[1] - 2.0*y[4] < YHMIN) y[1] = d->Y_H - 2.0*y[4] - YHMIN;
+	  }*/
 
-/*    if(y[2] < YHeMIN) {
-	y[2] = YHeMIN;
-	if (d->Y_He - y[2] - y[3] < YHeMIN) y[3] = d->Y_He - y[2] - YHeMIN;
-      }
-      if(y[3] < YHeMIN) {
-	y[3] = YHeMIN;
-	if (d->Y_He - y[2] - y[3] < YHeMIN) y[2] = d->Y_He - y[3] - YHeMIN;
-	}*/
+	if(y[2] < YHeMIN) y[2] = YHeMIN;
+	if(y[3] < YHeMIN) y[3] = YHeMIN;
+	if (d->Y_He - y[2] - y[3] < YHeMIN) {
+	  if (y[2] >= y[3]) y[2] = d->Y_He - y[3] - YHeMIN;
+	  else              y[3] = d->Y_He - y[2] - YHeMIN;
+	}
 
-      YTotal = (d->Y_H) - y[4] + (d->Y_H - y[1] - 2*y[4]) + d->Y_He + y[3] +
-	2.0*(d->Y_He - y[2] - y[3]) + d->ZMetal/MU_METAL;
-      EMin = clThermalEnergy( YTotal, cl->TMin );
+  /*    if(y[2] < YHeMIN) {
+	  y[2] = YHeMIN;
+	  if (d->Y_He - y[2] - y[3] < YHeMIN) y[3] = d->Y_He - y[2] - YHeMIN;
+	}
+	if(y[3] < YHeMIN) {
+	  y[3] = YHeMIN;
+	  if (d->Y_He - y[2] - y[3] < YHeMIN) y[2] = d->Y_He - y[3] - YHeMIN;
+	  }*/
+
+	YTotal = (d->Y_H) - y[4] + (d->Y_H - y[1] - 2*y[4]) + d->Y_He + y[3] +
+	  2.0*(d->Y_He - y[2] - y[3]) + d->ZMetal/MU_METAL;
+	EMin = clThermalEnergy( YTotal, cl->TMin );
 
 #ifdef ASSERTENEG      
-      assert(*y > 0.0);
+	assert(*y > 0.0);
 #else
-      if (y[0] < EMin) {
-	y[0] = EMin;
-/*	y[1] = YHMIN;
-	y[2] = d->Y_He;
-	y[3] = YHeMIN;
-	y[4] = d->Y_H/2.0;
-	printf("Emin: %e\n", EMin);
-	break;*/
+	if (y[0] < EMin) {
+	  y[0] = EMin;
+  /*	y[1] = YHMIN;
+	  y[2] = d->Y_He;
+	  y[3] = YHeMIN;
+	  y[4] = d->Y_H/2.0;
+	  printf("Emin: %e\n", EMin);
+	  break;*/
+	}
       }
 #endif   
    cl->its = 1;

--- a/cooling_metal_H2.c
+++ b/cooling_metal_H2.c
@@ -2942,10 +2942,6 @@ void clIntegrateEnergy(COOL *cl, clDerivsData *clData, PERBARYON *Y, double *E,
      ymin[3] = YHeMIN;
      ymin[4] = YH2MIN;
 
-      YTotal = (d->Y_H - ymin[4]) + (d->Y_H - ymin[1] - 2.0*ymin[4]) + d->Y_He + ymin[3] + 
-	2.0*(d->Y_He - ymin[2] - ymin[3]) + d->ZMetal/MU_METAL;
-      EMin = clThermalEnergy( YTotal, cl->TMin );
-      ymin[0] = EMin;
       StiffSetYMin(sbs, ymin);
 
       /*#ifdef COOLDEBUG      */

--- a/stiff.c
+++ b/stiff.c
@@ -230,7 +230,6 @@ cd
 	q[i] = 0.0;
 	d[i] = 0.0;
 	y0[i] = y[i];
-	y[i] = max(y[i], ymin[i]);
 	}
     
     s->derivs(tn + tstart, y, q, d, s->Data);
@@ -254,9 +253,6 @@ cd
 	scr2 = sign(1./y[i],.1*epsmin*ascr - d[i]);
 	scr1 = scr2 * d[i];
 	temp = -fabs(ascr-d[i])*scr2;
-	/* If the species is already at the minimum, disregard
-	   destruction when calculating step size */
-	if (y[i] == ymin[i]) temp = 0.0;
 	scrtch = max(scr1,max(temp,scrtch));
 	}
     dt = min(sqreps/scrtch,dtg);
@@ -313,7 +309,8 @@ cd
 		C ym2(i) = ym1(i)
 		C ym1(i) = y(i)
 		*/
-		y[i] = max(ys[i] + dt*scrarray[i], ymin[i]);
+		y[i] = ys[i] + dt*scrarray[i];
+		if (i == 0 && y[0] < ymin[0]) return;
 		}
 	    /*	    if(iter == 1) {  Removed from original algorithm
 		    so that previous, rather than first, corrector is


### PR DESCRIPTION
The metal and H2 cooling modules behave strangely as particles approach dCoolingTmin.  These problems become especially apparent when the superbubble feedback is enabled.

This PR fixes two issues with the cooling code at low temperature:

1. Before the StiffStep runs, the minimum energy is calculated using fixed values for the abundances. This creates a temperature offset between the edge of the cooling table and where the integrator actually stops. To fix this, the current abundances for a gas particle are now used to calculate EMin.

2. The chemeq version of StiffStep tries to prevent particles from falling off the cooling table bounds during integration. This seems to force particles near the bounds to take extremely tiny integration steps, which kills performance. To fix this, the integrator is now allowed to drop below EMin, but will immediately exit upon doing so. This probably means solutions for particles near dCoolingTmin are slightly wrong, but it also gives a 5-10x boost for performance when superbubble feedback is enabled.