### PR TITLE
Move snapshot writing code to a charm Group.

### DIFF
--- a/GravityParticle.h
+++ b/GravityParticle.h
@@ -434,6 +434,7 @@ public:
           p | dtKep;
           p | w;
 #endif
+          p | potential;
           p | dtGrav;
           p | fDensity;
           p | fBall;

--- a/InOutput.cpp
+++ b/InOutput.cpp
@@ -1099,8 +1099,8 @@ void Writer::setupWrite(int iStage, // stage of scan
                                                     duTFac, bDoublePos,
                                                     bDoubleVel, bCool, cb);
 	    }
-        //	if(thisIndex == (int) CkNumPes()-1)
-        //  assert(nStartWrite+myNumParticles == nTotalParticles);
+        if(thisIndex == (int) CkNumPes()-1)
+            assert(nStartWrite+vMyParticles.size() == nTotalParticles);
 	nSetupWriteStage = -1;	// reset for next time.
 	parallelWrite(0, cb, filename, dTime, dvFac, duTFac, bDoublePos,
                       bDoubleVel, bCool);
@@ -1274,7 +1274,7 @@ Writer::oneNodeWrite(int iIndex, // Index of Treepiece
     writeTipsy(*globalTipsyWriter, vParticles, dvFac, duTFac, bDoublePos,
                bDoubleVel, bCool);
     
-    if(iIndex < (numTreePieces - 1))
+    if(iIndex < (CkNumPes() - 1))
 	thisProxy[iIndex+1].serialWrite(iPrevOffset + vParticles.size(), filename,
 					dTime, dvFac, duTFac, 
                                         bDoublePos, bDoubleVel, bCool, cb);
@@ -1408,7 +1408,7 @@ void Writer::writeTipsy(Tipsy::TipsyWriter& w,
             else
                 write_tipsy_dark<double,double>(w, vParticles[i], dvFac);
 	    }
-	else if(vParticles[i+1].isStar()) {
+	else if(vParticles[i].isStar()) {
             if(!bDoublePos)
                 write_tipsy_star<float,float>(w, vParticles[i], dvFac);
             else if(!bDoubleVel)
@@ -1504,6 +1504,8 @@ void TreePiece::fillWriters(int64_t _nMaxOrder)
                              (binEnd-binBegin));
                 writeProxy[iPe].receive(vPartOut, vSPHOut, vStarOut);
 	    }
+            if(&myParticles[myNumParticles+1] <= binEnd)
+                break;
 	    binBegin = binEnd;
 	    }
 	}
@@ -1667,12 +1669,12 @@ void Writer::outputASCII(OutputParams& params, // specifies
       else {
         if(params.bFloat) {
 	  if(params.bVector && packed)
-	      avOut[i-1] = vOut;
+	      avOut[i] = vOut;
 	  else
-	      adOut[i-1] = dOut;
+	      adOut[i] = dOut;
 	  }
         else
-            aiOut[i-1] = iOut;
+            aiOut[i] = iOut;
         }
       }
   cnt++;

--- a/InOutput.cpp
+++ b/InOutput.cpp
@@ -2020,8 +2020,8 @@ void Main::cbIOClosed(CkMessage *msg)
     }
     else {
         CkReductionMsg *msgMinMax;
-        treeProxy.minmaxNCOut(*pOutput,
-                           CkCallbackResumeThread((void *&)msgMinMax));
+        writeProxy.minmaxNCOut(*pOutput,
+                               CkCallbackResumeThread((void *&)msgMinMax));
         pOutput->iTypeWriting >>= 1;  // Kludge quickly get the
                                          // current filename from
                                          // getNCNextOutput()
@@ -2097,22 +2097,22 @@ void Main::cbIOClosed(CkMessage *msg)
     cbIO.send();
 }
 
-void TreePiece::minmaxNCOut(OutputParams& params, const CkCallback& cb)
+void Writer::minmaxNCOut(OutputParams& params, const CkCallback& cb)
 {
     OrientedBox<float> bbVec;
     float minmax[2] = {FLT_MAX, -FLT_MAX};
     int64_t iminmax[2] = {INT_MAX, -INT_MAX};
     params.dm = dm; // pass cooling information
 
-    for(unsigned int i = 1; i <= myNumParticles; ++i) {
-        if((TYPETest(&myParticles[i], params.iType)
-            && TYPETest(&myParticles[i], params.iTypeWriting))
+    for(unsigned int i = 0; i < vMyParticles.size(); ++i) {
+        if((TYPETest(&vMyParticles[i], params.iType)
+            && TYPETest(&vMyParticles[i], params.iTypeWriting))
            || params.iBinaryOut != 6) {
           if(params.bFloat) {
             if(params.bVector)
-                bbVec.grow(params.vValue(&myParticles[i]));
+                bbVec.grow(params.vValue(&vMyParticles[i]));
             else {
-                float dValue = params.dValue(&myParticles[i]);
+                float dValue = params.dValue(&vMyParticles[i]);
                 if(dValue < minmax[0])
                     minmax[0] = dValue;
                 if(dValue > minmax[1])
@@ -2120,7 +2120,7 @@ void TreePiece::minmaxNCOut(OutputParams& params, const CkCallback& cb)
                 }
             }
           else {
-              int64_t iValue = params.iValue(&myParticles[i]);
+              int64_t iValue = params.iValue(&vMyParticles[i]);
               if(iValue < iminmax[0])
                   iminmax[0] = iValue;
               if(iValue > iminmax[1])

--- a/InOutput.cpp
+++ b/InOutput.cpp
@@ -10,6 +10,7 @@
 #include "TipsyFile.h"
 #include "OrientedBox.h"
 #include "Reductions.h"
+#include "Writer.h"
 #include "InOutput.h"
 #include "ckio.h"
 #include <errno.h>
@@ -405,7 +406,6 @@ void TreePiece::readTipsyArray(OutputParams& params, const CkCallback& cb)
         int nDim = 1;           // Dimensions to read
         if(params.bVector) {
             nDim = 3;
-            CkAssert(packed == 0);
         }
         for(int iDim = 0; iDim < nDim; iDim++) {
             for(int i = 0; i < nStartRead; i++) {
@@ -1048,7 +1048,7 @@ void TreePiece::readFloatBinary(OutputParams& params, int bParaRead,
 /// Perform Parallel Scan (a log(p) algorithm) to establish start of
 /// parallel writes, then do the writing.  Calls writeTipsy() to do
 /// the actual writing.
-void TreePiece::setupWrite(int iStage, // stage of scan
+void Writer::setupWrite(int iStage, // stage of scan
 			   u_int64_t iPrevOffset,
 			   const std::string& filename,
 			   const double dTime,
@@ -1061,7 +1061,7 @@ void TreePiece::setupWrite(int iStage, // stage of scan
 {
     if(iStage > nSetupWriteStage + 1) {
 	// requeue message
-	pieces[thisIndex].setupWrite(iStage, iPrevOffset, filename,
+	thisProxy[thisIndex].setupWrite(iStage, iPrevOffset, filename,
 				     dTime, dvFac, duTFac, bDoublePos,
                                      bDoubleVel, bCool, cb);
 	return;
@@ -1072,35 +1072,35 @@ void TreePiece::setupWrite(int iStage, // stage of scan
     
     int iOffset = 1 << nSetupWriteStage;
     nStartWrite += iPrevOffset;
-    if(thisIndex+iOffset < (int) numTreePieces) { // Scan on
+    if(thisIndex+iOffset < (int) CkNumPes()) { // Scan on
 	if(verbosity > 1) {
 	    ckerr << thisIndex << ": stage " << iStage << " sending "
-		  << nStartWrite+myNumParticles << " to " << thisIndex+iOffset
-		  << endl;
+		  << nStartWrite+vMyParticles.size() << " to "
+                  << thisIndex+iOffset << endl;
 	    }
-	pieces[thisIndex+iOffset].setupWrite(iStage+1,
-					     nStartWrite+myNumParticles,
-					     filename, dTime, dvFac, duTFac,
-					     bDoublePos, bDoubleVel, bCool, cb);
+	thisProxy[thisIndex+iOffset].setupWrite(iStage+1,
+                                                nStartWrite+vMyParticles.size(),
+                                                filename, dTime, dvFac, duTFac,
+                                                bDoublePos, bDoubleVel, bCool, cb);
 	}
     if(thisIndex < iOffset) { // No more messages are coming my way
 	// send out all the messages
-	for(iStage = iStage+1; (1 << iStage) + thisIndex < (int)numTreePieces;
+	for(iStage = iStage+1; (1 << iStage) + thisIndex < (int)CkNumPes();
 	    iStage++) {
 	    iOffset = 1 << iStage;
 	    if(verbosity > 1) {
 		ckerr << thisIndex << ": stage " << iStage << " sending "
-		      << nStartWrite+myNumParticles << " to "
+		      << nStartWrite+vMyParticles.size() << " to "
 		      << thisIndex+iOffset << endl;
 		}
-	    pieces[thisIndex+iOffset].setupWrite(iStage+1,
-						 nStartWrite+myNumParticles,
-						 filename, dTime, dvFac,
-						 duTFac, bDoublePos,
-                                                 bDoubleVel, bCool, cb);
+            thisProxy[thisIndex+iOffset].setupWrite(iStage+1,
+                                                    nStartWrite+vMyParticles.size(),
+                                                    filename, dTime, dvFac,
+                                                    duTFac, bDoublePos,
+                                                    bDoubleVel, bCool, cb);
 	    }
-	if(thisIndex == (int) numTreePieces-1)
-	    assert(nStartWrite+myNumParticles == nTotalParticles);
+        //	if(thisIndex == (int) CkNumPes()-1)
+        //  assert(nStartWrite+myNumParticles == nTotalParticles);
 	nSetupWriteStage = -1;	// reset for next time.
 	parallelWrite(0, cb, filename, dTime, dvFac, duTFac, bDoublePos,
                       bDoubleVel, bCool);
@@ -1112,7 +1112,7 @@ void TreePiece::setupWrite(int iStage, // stage of scan
 /// @param iPass What pass we are on in the parallel write.  The
 /// initial call should be with "0".
 
-void TreePiece::parallelWrite(int iPass, const CkCallback& cb,
+void Writer::parallelWrite(int iPass, const CkCallback& cb,
 			      const std::string& filename, const double dTime,
 			      const double dvFac, // scale velocities
 			      const double duTFac, // convert temperature
@@ -1131,11 +1131,12 @@ void TreePiece::parallelWrite(int iPass, const CkCallback& cb,
     if(nIOProcessor == 0) {	// use them all
 	Tipsy::TipsyWriter wAll(filename, tipsyHeader, false, bDoublePos,
                                 bDoubleVel);
-	writeTipsy(wAll, dvFac, duTFac, bDoublePos, bDoubleVel, bCool);
+	writeTipsy(wAll, vMyParticles, dvFac, duTFac, bDoublePos, bDoubleVel,
+                   bCool);
 	contribute(cb);
 	return;
 	}
-    int nSkip = numTreePieces/nIOProcessor;
+    int nSkip = CkNumPes()/nIOProcessor;
     if(nSkip == 0)
 	nSkip = 1;
     if(thisIndex%nSkip != iPass) { // N.B. this will only be the case
@@ -1144,9 +1145,9 @@ void TreePiece::parallelWrite(int iPass, const CkCallback& cb,
 	}
 
     Tipsy::TipsyWriter w(filename, tipsyHeader, false, bDoublePos, bDoubleVel);
-    writeTipsy(w, dvFac, duTFac, bDoublePos, bDoubleVel, bCool);
-    if(iPass < (nSkip - 1) && thisIndex < (numTreePieces - 1))
-	treeProxy[thisIndex+1].parallelWrite(iPass + 1, cb, filename, dTime,
+    writeTipsy(w, vMyParticles, dvFac, duTFac, bDoublePos, bDoubleVel, bCool);
+    if(iPass < (nSkip - 1) && thisIndex < (CkNumPes() - 1))
+	thisProxy[thisIndex+1].parallelWrite(iPass + 1, cb, filename, dTime,
 					     dvFac, duTFac, bDoublePos,
                                              bDoubleVel, bCool);
     contribute(cb);
@@ -1157,7 +1158,7 @@ void TreePiece::parallelWrite(int iPass, const CkCallback& cb,
 ///
 /// Send my particles to piece 0 for output.
 ///
-void TreePiece::serialWrite(const u_int64_t iPrevOffset, // previously written
+void Writer::serialWrite(const u_int64_t iPrevOffset, // previously written
 							 //particles
 			    const std::string& filename,  // output file
 			    const double dTime,	 // time or expansion
@@ -1169,35 +1170,36 @@ void TreePiece::serialWrite(const u_int64_t iPrevOffset, // previously written
 			    const CkCallback& cb)
 {
     int *piSph = NULL;
-    if(myNumSPH > 0)
-	piSph = new int[myNumSPH];
+    if(vMySPHParticles.size() > 0)
+	piSph = new int[vMySPHParticles.size()];
     int *piStar = NULL;
-    if(myNumStar > 0)
-	piStar = new int[myNumStar];
+    if(vMyStarParticles.size() > 0)
+	piStar = new int[vMyStarParticles.size()];
     /*
      * Calculate offsets to send across processors
      */
     int iGasOut = 0;
     int iStarOut = 0;
-    for(int iPart = 1; iPart <= myNumParticles ; iPart++) {
-	if(myParticles[iPart].isGas()) {
-	    piSph[iGasOut] = (extraSPHData *)myParticles[iPart].extraData
-		- mySPHParticles;
+    for(int iPart = 0; iPart < vMyParticles.size() ; iPart++) {
+	if(vMyParticles[iPart].isGas()) {
+	    piSph[iGasOut] = (extraSPHData *)vMyParticles[iPart].extraData
+		- &vMySPHParticles[0];
 	    iGasOut++;
 	    }
-	if(myParticles[iPart].isStar()) {
-	    piStar[iStarOut] = (extraStarData *)myParticles[iPart].extraData
-		- myStarParticles;
+	if(vMyParticles[iPart].isStar()) {
+	    piStar[iStarOut] = (extraStarData *)vMyParticles[iPart].extraData
+		- &vMyStarParticles[0];
 	    iStarOut++;
 	    }
 	}
-    pieces[0].oneNodeWrite(thisIndex, myNumParticles, myNumSPH, myNumStar,
-			   myParticles, mySPHParticles, myStarParticles,
+    thisProxy[0].oneNodeWrite(thisIndex, vMySPHParticles.size(),
+                              vMyStarParticles.size(),
+			   vMyParticles, vMySPHParticles, vMyStarParticles,
 			   piSph, piStar, iPrevOffset, filename, dTime,
 			   dvFac, duTFac, bDoublePos, bDoubleVel, bCool, cb);
-    if(myNumSPH > 0)
+    if(vMySPHParticles.size() > 0)
 	delete [] piSph;
-    if(myNumStar > 0)
+    if(vMyStarParticles.size() > 0)
 	delete [] piStar;
     }
 
@@ -1211,13 +1213,12 @@ Tipsy::TipsyWriter *globalTipsyWriter;
 
 /// @brief write out the particles I have been sent
 void
-TreePiece::oneNodeWrite(int iIndex, // Index of Treepiece
-			int iOutParticles, // number of particles
+Writer::oneNodeWrite(int iIndex, // Index of Treepiece
 			int iOutSPH, // number of SPH particles
 			int iOutStar, // number of Star particles
-			GravityParticle* particles, // particles to write
-			extraSPHData *pGas, // SPH data
-			extraStarData *pStar, // Star data
+                     std::vector<GravityParticle> vParticles, // particles to write
+                     std::vector<extraSPHData> vGas, // SPH data
+                     std::vector<extraStarData> vStar, // Star data
 			int *piSPH, // SPH data offsets
 			int *piStar, // Star data offsets
 			const u_int64_t iPrevOffset, // previously written
@@ -1236,28 +1237,16 @@ TreePiece::oneNodeWrite(int iIndex, // Index of Treepiece
      */
     int iGasOut = 0;
     int iStarOut = 0;
-    for(int iPart = 1; iPart <= iOutParticles; iPart++) {
-	if(particles[iPart].isGas()) {
-	    particles[iPart].extraData = pGas+ piSPH[iGasOut];
+    for(int iPart = 0; iPart < vParticles.size(); iPart++) {
+	if(vParticles[iPart].isGas()) {
+	    vParticles[iPart].extraData = vGas.data() + piSPH[iGasOut];
 	    iGasOut++;
 	    }
-	if(particles[iPart].isStar()) {
-	    particles[iPart].extraData = pStar+ piStar[iStarOut];
+	if(vParticles[iPart].isStar()) {
+	    vParticles[iPart].extraData = vStar.data() + piStar[iStarOut];
 	    iStarOut++;
 	    }
 	}
-    /*
-     * setup pointers/data for writeTipsy()
-     * XXX yes, this is gross.
-     */
-    int saveNumParticles = myNumParticles;
-    GravityParticle *saveMyParticles = myParticles;
-    extraSPHData *savemySPHParticles = mySPHParticles;
-    extraStarData *savemyStarParticles = myStarParticles;
-    myNumParticles = iOutParticles;
-    myParticles = particles;
-    mySPHParticles = pGas;
-    myStarParticles = pStar;
     nStartWrite = iPrevOffset;
     if(iIndex == 0) {
         // Create and truncate output file.    
@@ -1282,18 +1271,11 @@ TreePiece::oneNodeWrite(int iIndex, // Index of Treepiece
                                                    bDoubleVel);
 	}
 	    
-    writeTipsy(*globalTipsyWriter, dvFac, duTFac, bDoublePos, bDoubleVel,
-               bCool);
-    /*
-     * Restore pointers/data
-     */
-    myNumParticles = saveNumParticles;
-    myParticles = saveMyParticles;
-    mySPHParticles = savemySPHParticles;
-    myStarParticles = savemyStarParticles;
+    writeTipsy(*globalTipsyWriter, vParticles, dvFac, duTFac, bDoublePos,
+               bDoubleVel, bCool);
     
     if(iIndex < (numTreePieces - 1))
-	treeProxy[iIndex+1].serialWrite(iPrevOffset + iOutParticles, filename,
+	thisProxy[iIndex+1].serialWrite(iPrevOffset + vParticles.size(), filename,
 					dTime, dvFac, duTFac, 
                                         bDoublePos, bDoubleVel, bCool, cb);
     else {
@@ -1390,7 +1372,8 @@ void write_tipsy_star(Tipsy::TipsyWriter &w, GravityParticle &p,
     }
 }
 
-void TreePiece::writeTipsy(Tipsy::TipsyWriter& w,
+void Writer::writeTipsy(Tipsy::TipsyWriter& w,
+                        std::vector<GravityParticle>& vParticles,
 			   const double dvFac, // scale velocities
 			   const double duTFac, // convert temperature
                            const bool bDoublePos,
@@ -1400,38 +1383,38 @@ void TreePiece::writeTipsy(Tipsy::TipsyWriter& w,
     
     if(nStartWrite == 0)
 	w.writeHeader();
-    if(myNumParticles == 0)     // no particles to write
+    if(vParticles.size() == 0)     // no particles to write
         return;
     
     CkMustAssert(w.seekParticleNum(nStartWrite), "bad seek");
-    for(unsigned int i = 0; i < myNumParticles; i++) {
-	if(myParticles[i+1].isGas()) {
+    for(unsigned int i = 0; i < vParticles.size(); i++) {
+	if(vParticles[i].isGas()) {
             if(!bDoublePos)
-                write_tipsy_gas<float,float>(w, myParticles[i+1], dvFac,
+                write_tipsy_gas<float,float>(w, vParticles[i], dvFac,
                                              duTFac, bCool, dm->Cool);
             else if(!bDoubleVel)
-                write_tipsy_gas<double,float>(w, myParticles[i+1], dvFac,
+                write_tipsy_gas<double,float>(w, vParticles[i], dvFac,
                                               duTFac, bCool, dm->Cool);
             else
-                write_tipsy_gas<double,double>(w, myParticles[i+1], dvFac,
+                write_tipsy_gas<double,double>(w, vParticles[i], dvFac,
                                                duTFac, bCool, dm->Cool);
                 
 	    }
-	else if(myParticles[i+1].isDark()) {
+	else if(vParticles[i].isDark()) {
             if(!bDoublePos)
-                write_tipsy_dark<float,float>(w, myParticles[i+1], dvFac);
+                write_tipsy_dark<float,float>(w, vParticles[i], dvFac);
             else if(!bDoubleVel)
-                write_tipsy_dark<double,float>(w, myParticles[i+1], dvFac);
+                write_tipsy_dark<double,float>(w, vParticles[i], dvFac);
             else
-                write_tipsy_dark<double,double>(w, myParticles[i+1], dvFac);
+                write_tipsy_dark<double,double>(w, vParticles[i], dvFac);
 	    }
-	else if(myParticles[i+1].isStar()) {
+	else if(vParticles[i+1].isStar()) {
             if(!bDoublePos)
-                write_tipsy_star<float,float>(w, myParticles[i+1], dvFac);
+                write_tipsy_star<float,float>(w, vParticles[i], dvFac);
             else if(!bDoubleVel)
-                write_tipsy_star<double,float>(w, myParticles[i+1], dvFac);
+                write_tipsy_star<double,float>(w, vParticles[i], dvFac);
             else
-                write_tipsy_star<double,double>(w, myParticles[i+1], dvFac);
+                write_tipsy_star<double,double>(w, vParticles[i], dvFac);
 	    }
 	else {
 	    CkAbort("Bad particle type in tipsyWrite");
@@ -1450,45 +1433,42 @@ static bool compIOrder(const GravityParticle& first,
 ///
 /// @brief Calculate boundaries based on iOrder
 ///
-inline int64_t *iOrderBoundaries(int nPieces, int64_t nMaxOrder) 
+inline int64_t iOrderBoundaries(int nPieces, int iPiece, int64_t nMaxOrder) 
 {
-    int64_t *startParticle = new int64_t[nPieces+1];
-    int iPiece;
+    if(iPiece == nPieces)
+        return nMaxOrder+1;
 
     // Note that with particle creation/destruction this will not be
     // perfectly balanced.
     //
-    for(iPiece = 0; iPiece < nPieces; iPiece++) {
-	int64_t nOutParticles = nMaxOrder/ nPieces;
-	startParticle[iPiece] = nOutParticles * iPiece;
-	}
-    startParticle[nPieces] = nMaxOrder+1;
-    return startParticle;
+    int64_t nOutParticles = nMaxOrder/ nPieces;
+    return nOutParticles * iPiece;
     }
 
 ///
-/// @brief Reorder particles for output
+/// @brief Perform operations to prepare for output.
+///
+void Main::reOrder() {
+    ckout << "Reordering ...";
+    double startTime = CkWallTimer();
+    writeProxy.clear(nTotalParticles, nTotalSPH, nTotalDark, nTotalStar,
+                     CkCallbackResumeThread());
+    treeProxy.fillWriters(nMaxOrder);
+    CkWaitQD(); // Wait until Writers are filled.
+    writeProxy.reOrder(CkCallbackResumeThread());
+    ckout << " took " << (CkWallTimer() - startTime) << " seconds." << endl;
+}
+
+///
+/// @brief 
 /// @param _nMaxOrder Maximum iOrder used to calculate TreePiece
 /// boundaries for output.
-/// @param cb Callback for when all the shuffling is done.
 ///
-/// After determining iOrder boundaries, the number of particles in
-/// each TreePiece is calculated via a reduction.
-///
-void TreePiece::reOrder(int64_t _nMaxOrder, const CkCallback& cb)
+void TreePiece::fillWriters(int64_t _nMaxOrder)
 {
     LBTurnInstrumentOff();      // The load balancer should not
                                 // measure output timings.
-    callback = cb; // Save callback for after shuffle
-    int *counts = new int[numTreePieces];
-    int iPiece;
-    
     nMaxOrder = _nMaxOrder;
-    for(iPiece = 0; iPiece < numTreePieces; iPiece++) {
-	counts[iPiece] = 0;
-	}
-
-    int64_t *startParticle = iOrderBoundaries(numTreePieces, nMaxOrder);
 
     if (myNumParticles > 0) {
 	// Sort particles in iOrder
@@ -1500,231 +1480,94 @@ void TreePiece::reOrder(int64_t _nMaxOrder, const CkCallback& cb)
 	// Loop through to get particle counts.
 	GravityParticle *binBegin = &myParticles[1];
 	GravityParticle *binEnd;
-	for(iPiece = 0; iPiece < numTreePieces; iPiece++) {
-	    for(binEnd = binBegin; binEnd->iOrder < startParticle[iPiece+1];
+	for(int iPe = 0; iPe < CkNumPes(); iPe++) {
+            int64_t nextStartParticle = iOrderBoundaries(CkNumPes(), iPe+1, nMaxOrder);
+	    for(binEnd = binBegin; binEnd->iOrder < nextStartParticle;
 		binEnd++);
 	    int nPartOut = binEnd - binBegin;
-	    counts[iPiece] = nPartOut;
-	    if(&myParticles[myNumParticles + 1] <= binEnd)
-		break;
+            if(nPartOut > 0) {
+                std::vector<GravityParticle> vPartOut;
+                std::vector<extraSPHData> vSPHOut;
+                std::vector<extraStarData> vStarOut;
+
+                for(GravityParticle *pPart = binBegin; pPart < binEnd; pPart++) {
+                    vPartOut.push_back(*pPart);
+                    if(pPart->isGas()) {
+                        vSPHOut.push_back(*(extraSPHData *)pPart->extraData);
+		    }
+                    if(pPart->isStar()) {
+			vStarOut.push_back(*(extraStarData *)pPart->extraData);
+		    }
+		}
+                if (verbosity>=3)
+                    CkPrintf("me:%d to:%d how many:%ld\n",thisIndex, iPe,
+                             (binEnd-binBegin));
+                writeProxy[iPe].receive(vPartOut, vSPHOut, vStarOut);
+	    }
 	    binBegin = binEnd;
 	    }
 	}
-    myIOParticles = -1;
-    CkCallback cbShuffle = CkCallback(CkIndex_TreePiece::ioShuffle(NULL),
-				      pieces);
-    contribute(numTreePieces*sizeof(int), counts, CkReduction::sum_int,
-	       cbShuffle);
-    delete [] startParticle;
-    delete [] counts;
     }
 
-///
-/// @brief Perform the shuffle for reOrder
-///
-void TreePiece::ioShuffle(CkReductionMsg *msg) 
+/// @brief Initialize the data structures in preparation for receiving
+/// particles for writing.
+/// @param nTotal Total number of particles in the snapshot
+/// @param nSPH Total number of SPH particles in the snapshot
+/// @param nDark Total number of Dark particles in the snapshot
+/// @param nStar Total number of Star particles in the snapshot
+/// @param cb Callback when done.
+void Writer::clear(int64_t nTotal, int64_t nSPH, int64_t nDark, int64_t nStar,
+                   const CkCallback& cb)
 {
-    int *counts = (int *)msg->getData();
-    myIOParticles = counts[thisIndex];
-    delete msg;
-    
-    int iPiece;
-    
-    //
-    // Calculate iOrder boundaries for all processors
-    //
-    int64_t *startParticle = iOrderBoundaries(numTreePieces, nMaxOrder);
+    nTotalParticles = nTotal;
+    nTotalSPH = nSPH;
+    nTotalDark = nDark;
+    nTotalStar = nStar;
+    vMyParticles.clear();
+    vMySPHParticles.clear();
+    vMyStarParticles.clear();
+    dm = (DataManager*)CkLocalNodeBranch(dataManagerID);
+    contribute(cb);
+}
 
-    double tpLoad = getObjTime();
-    populateSavedPhaseData(iPrevRungLB, tpLoad, nPrevActiveParts);
-
-    if (myNumParticles > 0) {
-	// Particles have been sorted in reOrder()
-    // Loop through sending particles to correct processor.
-    GravityParticle *binBegin = &myParticles[1];
-    GravityParticle *binEnd;
-    for(iPiece = 0; iPiece < numTreePieces; iPiece++) {
-	for(binEnd = binBegin; binEnd->iOrder < startParticle[iPiece+1];
-	    binEnd++);
-	int nPartOut = binEnd - binBegin;
-  int saved_phase_len = savedPhaseLoad.size();
-	if(nPartOut > 0) {
-	    int nGasOut = 0;
-	    int nStarOut = 0;
-	    for(GravityParticle *pPart = binBegin; pPart < binEnd; pPart++) {
-		if(pPart->isGas())
-		    nGasOut++;
-		if(pPart->isStar())
-		    nStarOut++;
-		}
-	    ParticleShuffleMsg *shuffleMsg
-		= new (saved_phase_len, saved_phase_len, nPartOut, nGasOut, nStarOut)
-		ParticleShuffleMsg(saved_phase_len, nPartOut, nGasOut, nStarOut);
-    memset(shuffleMsg->parts_per_phase, 0, saved_phase_len*sizeof(unsigned int));
-	    int iGasOut = 0;
-	    int iStarOut = 0;
-	    GravityParticle *pPartOut = shuffleMsg->particles;
-	    for(GravityParticle *pPart = binBegin; pPart < binEnd;
-		pPart++, pPartOut++) {
-		*pPartOut = *pPart;
-		if(pPart->isGas()) {
-		    shuffleMsg->pGas[iGasOut]
-			= *(extraSPHData *)pPart->extraData;
-		    iGasOut++;
-		    }
-		if(pPart->isStar()) {
-		    shuffleMsg->pStar[iStarOut]
-			= *(extraStarData *)pPart->extraData;
-		    iStarOut++;
-		    }
-
-        for(int i = 0; i < saved_phase_len; i++) {
-          if (pPart->rung >= i) {
-            shuffleMsg->parts_per_phase[i] = shuffleMsg->parts_per_phase[i] + 1;
-          }
-        }
-        if(havePhaseData(PHASE_FEEDBACK)
-           && (pPart->isGas() || pPart->isStar()))
-            shuffleMsg->parts_per_phase[PHASE_FEEDBACK] += 1;
-		}
-      memset(shuffleMsg->loads, 0.0, saved_phase_len*sizeof(double));
-
-      // Calculate the partial load per phase
-      for (int i = 0; i < saved_phase_len; i++) {
-        if (havePhaseData(i) && savedPhaseParticle[i] != 0) {
-          shuffleMsg->loads[i] = savedPhaseLoad[i] *
-            (shuffleMsg->parts_per_phase[i] / (float) savedPhaseParticle[i]);
-        } else if (havePhaseData(0) && myNumParticles != 0) {
-          shuffleMsg->loads[i] = savedPhaseLoad[0] *
-            (shuffleMsg->parts_per_phase[i] / (float) myNumParticles);
-        }
-      }
+///
+/// @brief Accumulate particle data from the TreePieces.
+/// @param vPart Particle data
+/// @param vSPH  extraData for SPH particles
+/// @param vStar  extraData for Star particles
+///
+void Writer::receive(std::vector<GravityParticle> vPart, std::vector<extraSPHData> vSPH,
+                     std::vector<extraStarData> vStar) 
+{
+    vMyParticles.insert(vMyParticles.end(), vPart.begin(), vPart.end());
+    vMySPHParticles.insert(vMySPHParticles.end(), vSPH.begin(), vSPH.end());
+    vMyStarParticles.insert(vMyStarParticles.end(), vStar.begin(), vStar.end());
+}
 
 
-
-	    if (verbosity>=3)
-		CkPrintf("me:%d to:%d how many:%ld\n",thisIndex, iPiece,
-			 (binEnd-binBegin));
-	    if(iPiece == thisIndex) {
-		ioAcceptSortedParticles(shuffleMsg);
-		}
-	    else {
-		pieces[iPiece].ioAcceptSortedParticles(shuffleMsg);
-		}
-	    }
-	if(&myParticles[myNumParticles + 1] <= binEnd)
-	    break;
-	binBegin = binEnd;
-	}
-    }
-	
-    delete[] startParticle;
-
-    // signify completion
-    incomingParticlesSelf = true;
-    ioAcceptSortedParticles(NULL);
-    }
-
-/// Accept particles from other TreePieces once the sorting has finished
-void TreePiece::ioAcceptSortedParticles(ParticleShuffleMsg *shuffleMsg) {
-
-    if(shuffleMsg != NULL) {
-	incomingParticlesMsg.push_back(shuffleMsg);
-	incomingParticlesArrived += shuffleMsg->n;
-        savePhaseData(savedPhaseLoadTmp, savedPhaseParticleTmp, shuffleMsg->loads,
-            shuffleMsg->parts_per_phase, shuffleMsg->nloads);
-	}
-
-    if(verbosity > 2)
-	ckout << thisIndex << ": incoming: " << incomingParticlesArrived
-	      << " myIO: " << myIOParticles << endl;
-    
-  if(myIOParticles == incomingParticlesArrived && incomingParticlesSelf) {
-      //I've got all my particles, now count them
-    if(verbosity>1) ckout << thisIndex <<" got ioParticles"
-			  <<endl;
-
-    savedPhaseLoad.swap(savedPhaseLoadTmp);
-    savedPhaseParticle.swap(savedPhaseParticleTmp);
-    savedPhaseLoadTmp.clear();
-    savedPhaseParticleTmp.clear();
-
-    int nTotal = 0;
-    int nSPH = 0;
-    int nStar = 0;
-    int iMsg;
-    for(iMsg = 0; iMsg < incomingParticlesMsg.size(); iMsg++) {
-	nTotal += incomingParticlesMsg[iMsg]->n;
-	nSPH += incomingParticlesMsg[iMsg]->nSPH;
-	nStar += incomingParticlesMsg[iMsg]->nStar;
-	}
-      
-    if (myNumParticles > 0) delete[] myParticles;
-    nStore = (int) ((nTotal + 2)*(1.0 + dExtraStore));
-    myParticles = new GravityParticle[nStore];
-    myNumParticles = nTotal;
-    // reset for next time
-    incomingParticlesArrived = 0;
-    incomingParticlesSelf = false;
-
-    myNumSPH = nSPH;
-    if (nStoreSPH > 0) delete[] mySPHParticles;
-    nStoreSPH = (int) (myNumSPH*(1.0 + dExtraStore));
-    if(nStoreSPH > 0)
-        mySPHParticles = new extraSPHData[nStoreSPH];
-    else
-        mySPHParticles = NULL;
-
-    myNumStar = nStar;
-    if(nStoreStar > 0) delete[] myStarParticles;
-    allocateStars();
-
-    int nPart = 0;
-    nSPH = 0;
-    nStar = 0;
-    for(iMsg = 0; iMsg < incomingParticlesMsg.size(); iMsg++) {
-	memcpy(&myParticles[nPart+1], incomingParticlesMsg[iMsg]->particles,
-	       incomingParticlesMsg[iMsg]->n*sizeof(GravityParticle));
-	nPart += incomingParticlesMsg[iMsg]->n;
-	memcpy(&mySPHParticles[nSPH], incomingParticlesMsg[iMsg]->pGas,
-	       incomingParticlesMsg[iMsg]->nSPH*sizeof(extraSPHData));
-	nSPH += incomingParticlesMsg[iMsg]->nSPH;
-	memcpy(&myStarParticles[nStar], incomingParticlesMsg[iMsg]->pStar,
-	       incomingParticlesMsg[iMsg]->nStar*sizeof(extraStarData));
-	nStar += incomingParticlesMsg[iMsg]->nStar;
-	delete incomingParticlesMsg[iMsg];
-	}
-      
-    incomingParticlesMsg.clear();
-
+/// @ brief Reorder particles according to iOrder once they have all
+/// been received
+void Writer::reOrder(const CkCallback &cb) {
     // assign gas data pointers
     int iGas = 0;
     int iStar = 0;
-    for(int iPart = 0; iPart < myNumParticles; iPart++) {
-	if(myParticles[iPart+1].isGas()) {
-	    myParticles[iPart+1].extraData
-		= (extraSPHData *)&mySPHParticles[iGas];
+    for(int iPart = 0; iPart < vMyParticles.size(); iPart++) {
+	if(vMyParticles[iPart].isGas()) {
+	    vMyParticles[iPart].extraData = (void *)&vMySPHParticles[iGas];
 	    iGas++;
-	    }
-	if(myParticles[iPart+1].isStar()) {
-	    myParticles[iPart+1].extraData
-		= (extraStarData *)&myStarParticles[iStar];
+        }
+	if(vMyParticles[iPart].isStar()) {
+	    vMyParticles[iPart].extraData = (void *)&vMyStarParticles[iStar];
 	    iStar++;
-	    }
-	}
+        }
+    }
 
-    sort(myParticles+1, myParticles+myNumParticles+1, compIOrder);
-    //signify completion with a reduction
-    if(verbosity>1) ckout << thisIndex <<" contributing to ioAccept particles"
-			  <<endl;
-
-    deleteTree();
-    contribute(callback);
-  }
+    std::sort(vMyParticles.begin(), vMyParticles.end(), compIOrder);
+    contribute(cb);
 }
 
 // Output a Tipsy ASCII array file.
-void TreePiece::outputASCII(OutputParams& params, // specifies
+void Writer::outputASCII(OutputParams& params, // specifies
 						  // filename, format,
 						  // and quantity to
 						  // be output
@@ -1742,7 +1585,7 @@ void TreePiece::outputASCII(OutputParams& params, // specifies
   
   if((thisIndex==0 && packed) || (thisIndex==0 && !packed && cnt==0)) {
     if(verbosity > 2)
-      ckout << "TreePiece " << thisIndex << ": Writing header for output file" << endl;
+      ckout << "Writer " << thisIndex << ": Writing header for output file" << endl;
     outfile = CmiFopen((params.fileName+"."+params.sTipsyExt).c_str(), "w");
     CkAssert(outfile != NULL);
     fprintf(outfile,"%d\n",(int) nTotalParticles);
@@ -1750,32 +1593,32 @@ void TreePiece::outputASCII(OutputParams& params, // specifies
   }
 	
   if(verbosity > 3)
-    ckout << "TreePiece " << thisIndex << ": Writing output to disk" << endl;
+    ckout << "Writer " << thisIndex << ": Writing output to disk" << endl;
 	
   if(bParaWrite) {
       outfile = CmiFopen((params.fileName+"."+params.sTipsyExt).c_str(), "a");
       if(outfile == NULL)
-	    ckerr << "Treepiece " << thisIndex << " failed to open "
+	    ckerr << "Writer " << thisIndex << " failed to open "
 		  << params.fileName.c_str() << " : " << errno << endl;
       CkAssert(outfile != NULL);
       }
   else {
       if(params.bFloat) {
           if(params.bVector && packed)
-              avOut = new Vector3D<double>[myNumParticles];
+              avOut = new Vector3D<double>[vMyParticles.size()];
           else
-              adOut = new double[myNumParticles];
+              adOut = new double[vMyParticles.size()];
           }
       else
-          aiOut = new int[myNumParticles];
+          aiOut = new int[vMyParticles.size()];
       }
-    for(unsigned int i = 1; i <= myNumParticles; ++i) {
+  for(unsigned int i = 0; i < vMyParticles.size(); ++i) {
       Vector3D<double> vOut;
       double dOut;
       int iOut;
       if(params.bFloat) {
           if(params.bVector) {
-              vOut = params.vValue(&myParticles[i]);
+              vOut = params.vValue(&vMyParticles[i]);
               if(!packed){
                   if(cnt==0)
                       dOut = vOut.x;
@@ -1786,37 +1629,37 @@ void TreePiece::outputASCII(OutputParams& params, // specifies
                   }
               }
           else
-              dOut = params.dValue(&myParticles[i]);
+              dOut = params.dValue(&vMyParticles[i]);
           }
       else
-          iOut = params.iValue(&myParticles[i]);
+          iOut = params.iValue(&vMyParticles[i]);
       
       if(bParaWrite) {
         if(params.bFloat) {
 	  if(params.bVector && packed){
 	      if(fprintf(outfile,"%.14g\n",vOut.x) < 0) {
-		  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+		  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 		    CkAbort("Badness");
 		    }
 	      if(fprintf(outfile,"%.14g\n",vOut.y) < 0) {
-		  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+		  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 		  CkAbort("Badness");
 		  }
 	      if(fprintf(outfile,"%.14g\n",vOut.z) < 0) {
-		  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+		  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 		  CkAbort("Badness");
 		  }
 	      }
 	  else {
 	      if(fprintf(outfile,"%.14g\n",dOut) < 0) {
-		  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+		  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 		  CkAbort("Badness");
 		  }
 	      }
             }
         else {
             if(fprintf(outfile,"%d\n", iOut) < 0) {
-                ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+                ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
                 CkAbort("Badness");
                 }
             }
@@ -1842,8 +1685,8 @@ void TreePiece::outputASCII(OutputParams& params, // specifies
 	    ckerr << "Bad close: " << strerror(errno) << endl;
       CkAssert(result == 0);
 
-      if(thisIndex!=(int)numTreePieces-1) {
-	  pieces[thisIndex + 1].outputASCII(params, bParaWrite, cb);
+      if(thisIndex!=(int)CkNumPes()-1) {
+	  thisProxy[thisIndex + 1].outputASCII(params, bParaWrite, cb);
 	  return;
 	  }
 
@@ -1852,24 +1695,25 @@ void TreePiece::outputASCII(OutputParams& params, // specifies
 	  return;
 	  }
       // go through pieces again for unpacked vector.
-      pieces[0].outputASCII(params, bParaWrite, cb);
+      thisProxy[0].outputASCII(params, bParaWrite, cb);
       }
   else {
       int bDone = packed || !params.bVector || (!packed && cnt==0); // flag for last time
       if(params.bFloat) {
           if(params.bVector && packed) {
-              pieces[0].oneNodeOutVec(params, avOut, myNumParticles, thisIndex,
-                                      bDone, cb);
+              thisProxy[0].oneNodeOutVec(params, avOut, vMyParticles.size(),
+                                         thisIndex, bDone, cb);
               delete [] avOut;
               }
           else {
-              pieces[0].oneNodeOutArr(params, adOut, myNumParticles, thisIndex,
-                                      bDone, cb);
+              thisProxy[0].oneNodeOutArr(params, adOut, vMyParticles.size(),
+                                         thisIndex, bDone, cb);
               delete [] adOut;
               }
           }
       else {
-          pieces[0].oneNodeOutIntArr(params, aiOut, myNumParticles, thisIndex, cb);
+          thisProxy[0].oneNodeOutIntArr(params, aiOut, vMyParticles.size(),
+                                        thisIndex, cb);
           delete [] aiOut;
           }
       }
@@ -1878,7 +1722,7 @@ void TreePiece::outputASCII(OutputParams& params, // specifies
 // Receives an array of vectors to write out in ASCII format
 // Assumed to be called from outputASCII() and will continue with the
 // next tree piece unless "bDone".
-void TreePiece::oneNodeOutVec(OutputParams& params,
+void Writer::oneNodeOutVec(OutputParams& params,
 			      Vector3D<double>* avOut, // array to be output
 			      int nPart, // number of elements in avOut
 			      int iIndex, // treepiece which called me
@@ -1887,20 +1731,20 @@ void TreePiece::oneNodeOutVec(OutputParams& params,
 {
     FILE* outfile = CmiFopen((params.fileName+"."+params.sTipsyExt).c_str(), "a");
     if(outfile == NULL)
-	ckerr << "Treepiece " << thisIndex << " failed to open "
+	ckerr << "Writer " << thisIndex << " failed to open "
 	      << params.fileName.c_str() << " : " << errno << endl;
     CkAssert(outfile != NULL);
     for(int i = 0; i < nPart; ++i) {
 	if(fprintf(outfile,"%.14g\n",avOut[i].x) < 0) {
-	  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+	  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 	    CkAbort("Badness");
 	    }
 	if(fprintf(outfile,"%.14g\n",avOut[i].y) < 0) {
-	  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+	  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 	  CkAbort("Badness");
 	  }
 	if(fprintf(outfile,"%.14g\n",avOut[i].z) < 0) {
-	  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+	  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 	  CkAbort("Badness");
 	  }
 	}
@@ -1909,8 +1753,8 @@ void TreePiece::oneNodeOutVec(OutputParams& params,
 	ckerr << "Bad close: " << strerror(errno) << endl;
     CkAssert(result == 0);
 
-    if(iIndex!=(int)numTreePieces-1) {
-	  pieces[iIndex + 1].outputASCII(params, 0, cb);
+    if(iIndex!=(int)CkNumPes()-1) {
+	  thisProxy[iIndex + 1].outputASCII(params, 0, cb);
 	  return;
 	  }
 
@@ -1925,7 +1769,7 @@ void TreePiece::oneNodeOutVec(OutputParams& params,
 // Assumed to be called from outputASCII() and will continue with the
 // next tree piece unless "bDone"
 
-void TreePiece::oneNodeOutArr(OutputParams& params,
+void Writer::oneNodeOutArr(OutputParams& params,
 			      double *adOut, // array to be output
 			      int nPart, // length of adOut
 			      int iIndex, // treepiece which called me
@@ -1934,12 +1778,12 @@ void TreePiece::oneNodeOutArr(OutputParams& params,
 {
     FILE* outfile = CmiFopen((params.fileName+"."+params.sTipsyExt).c_str(), "a");
     if(outfile == NULL)
-	ckerr << "Treepiece " << thisIndex << " failed to open "
+	ckerr << "Writer " << thisIndex << " failed to open "
 	      << params.fileName.c_str() << " : " << errno << endl;
     CkAssert(outfile != NULL);
     for(int i = 0; i < nPart; ++i) {
 	if(fprintf(outfile,"%.14g\n",adOut[i]) < 0) {
-	  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+	  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 	    CkAbort("Badness");
 	    }
 	}
@@ -1948,8 +1792,8 @@ void TreePiece::oneNodeOutArr(OutputParams& params,
 	ckerr << "Bad close: " << strerror(errno) << endl;
     CkAssert(result == 0);
 
-    if(iIndex!=(int)numTreePieces-1) {
-	  pieces[iIndex + 1].outputASCII(params, 0, cb);
+    if(iIndex!=(int)CkNumPes()-1) {
+	  thisProxy[iIndex + 1].outputASCII(params, 0, cb);
 	  return;
 	  }
 
@@ -1958,14 +1802,14 @@ void TreePiece::oneNodeOutArr(OutputParams& params,
 	  return;
 	  }
     // go through pieces again for unpacked vector.
-    pieces[0].outputASCII(params, 0, cb);
+    thisProxy[0].outputASCII(params, 0, cb);
     }
 
 // Receives an array of ints to write out in ASCII format
 // Assumed to be called from outputASCII() and will continue with the
 // next tree piece.
 
-void TreePiece::oneNodeOutIntArr(OutputParams& params,
+void Writer::oneNodeOutIntArr(OutputParams& params,
 			      int *aiOut, // array to be output
 			      int nPart, // length of adOut
 			      int iIndex, // treepiece which called me
@@ -1973,12 +1817,12 @@ void TreePiece::oneNodeOutIntArr(OutputParams& params,
 {
     FILE* outfile = CmiFopen((params.fileName+"."+params.sTipsyExt).c_str(), "a");
     if(outfile == NULL)
-	ckerr << "Treepiece " << thisIndex << " failed to open "
+	ckerr << "Writer " << thisIndex << " failed to open "
 	      << params.fileName.c_str() << " : " << errno << endl;
     CkAssert(outfile != NULL);
     for(int i = 0; i < nPart; ++i) {
 	if(fprintf(outfile,"%d\n",aiOut[i]) < 0) {
-	  ckerr << "TreePiece " << thisIndex << ": Error writing array to disk, aborting" << endl;
+	  ckerr << "Writer " << thisIndex << ": Error writing array to disk, aborting" << endl;
 	    CkAbort("Badness");
 	    }
 	}
@@ -1986,8 +1830,8 @@ void TreePiece::oneNodeOutIntArr(OutputParams& params,
     if(result != 0)
 	ckerr << "Bad close: " << strerror(errno) << endl;
     CkAssert(result == 0);
-    if(iIndex!=(int)numTreePieces-1) {
-	  pieces[iIndex + 1].outputASCII(params, 0, cb);
+    if(iIndex!=(int)CkNumPes()-1) {
+	  thisProxy[iIndex + 1].outputASCII(params, 0, cb);
 	  return;
 	  }
 
@@ -2066,7 +1910,7 @@ std::string Main::getNCNextOutput(OutputParams& params)
     return "";
 }
 
-/// Determine offsets for all pieces, then start the write session.
+/// Determine offsets for all Writers, then start the write session.
 /// This needs to be a threaded entry method.
 void Main::cbOpen(Ck::IO::FileReadyMsg *msg)
 {
@@ -2103,7 +1947,7 @@ void Main::cbOpen(Ck::IO::FileReadyMsg *msg)
     if(pOutput->bVector) 
         nBytes *= 3;
     // XXX This would be better as a parallel prefix operation       
-    treeProxy[0].outputBinaryStart(*pOutput, 0, CkCallbackResumeThread());
+    writeProxy[0].outputBinaryStart(*pOutput, 0, CkCallbackResumeThread());
     fIOFile = msg->file;
     Ck::IO::startSession(msg->file, nBytes + nHeader, 0,
                          CkCallback(CkIndex_Main::cbIOReady(NULL), thishandle),
@@ -2112,37 +1956,38 @@ void Main::cbOpen(Ck::IO::FileReadyMsg *msg)
 }
 
 /// Determine start offsets for this piece based on previous pieces.
-void TreePiece::outputBinaryStart(OutputParams& params, int64_t nStart,
+void Writer::outputBinaryStart(OutputParams& params, int64_t nStart,
                                   const CkCallback& cb)
 {
     nStartWrite = nStart;
 
-    if(thisIndex == numTreePieces - 1) {
+    if(thisIndex == CkNumPes() - 1) {
         cb.send();
         return;
         }
 
     int64_t nMyParts;
     if(params.iBinaryOut != 6) {
-        nMyParts = myNumParticles;
+        nMyParts = vMyParticles.size();
     }
     else {
         if(params.iTypeWriting == TYPE_GAS)
-            nMyParts = myNumSPH;
+            nMyParts = vMySPHParticles.size();
         else if(params.iTypeWriting == TYPE_DARK)
-            nMyParts = myNumParticles - myNumSPH - myNumStar;
+            nMyParts = vMyParticles.size() - vMySPHParticles.size()
+                - vMyStarParticles.size();
         else if(params.iTypeWriting == TYPE_STAR)
-            nMyParts = myNumStar;
+            nMyParts = vMyStarParticles.size();
         else
             CkAbort("Bad writing type.");
         }
-    pieces[thisIndex+1].outputBinaryStart(params, nStart + nMyParts, cb);
+    thisProxy[thisIndex+1].outputBinaryStart(params, nStart + nMyParts, cb);
 }
 
 /// Session is ready; write my data.
 void Main::cbIOReady(Ck::IO::SessionReadyMsg *msg)
 {
-    treeProxy.outputBinary(msg->session, *pOutput);
+    writeProxy.outputBinary(msg->session, *pOutput);
     delete msg;
 }
 
@@ -2295,18 +2140,18 @@ void TreePiece::minmaxNCOut(OutputParams& params, const CkCallback& cb)
 }
  
 /// Output a Tipsy XDR binary float array file.
-void TreePiece::outputBinary(Ck::IO::Session session, OutputParams& params)
+void Writer::outputBinary(Ck::IO::Session session, OutputParams& params)
 {
     XDR xdrs;
     params.dm = dm; // pass cooling information
 
     if(verbosity > 3)
-	CkPrintf("TreePiece %d: Writing output to disk\n", thisIndex);
+	CkPrintf("Writer %d: Writing output to disk\n", thisIndex);
     
     int64_t nMyParts;
     size_t nHeader;
     if(params.iBinaryOut != 6) {
-        nMyParts = myNumParticles;
+        nMyParts = vMyParticles.size();
         nHeader = sizeof(int);
     }
     else {
@@ -2320,11 +2165,12 @@ void TreePiece::outputBinary(Ck::IO::Session session, OutputParams& params)
         else
             nHeader += 2*sizeof(int64_t);
         if(params.iTypeWriting == TYPE_GAS)
-            nMyParts = myNumSPH;
+            nMyParts = vMySPHParticles.size();
         else if(params.iTypeWriting == TYPE_DARK)
-            nMyParts = myNumParticles - myNumSPH - myNumStar;
+            nMyParts = vMyParticles.size() - vMySPHParticles.size()
+                - vMyStarParticles.size();
         else if(params.iTypeWriting == TYPE_STAR)
-            nMyParts = myNumStar;
+            nMyParts = vMyStarParticles.size();
         else
             CkAbort("Bad writing type.");
         }
@@ -2402,27 +2248,27 @@ void TreePiece::outputBinary(Ck::IO::Session session, OutputParams& params)
     
     int nOut = 0;
 
-    for(unsigned int i = 1; i <= myNumParticles; ++i) {
-        if((TYPETest(&myParticles[i], params.iType)
-            && TYPETest(&myParticles[i], params.iTypeWriting))
+    for(unsigned int i = 0; i < vMyParticles.size(); ++i) {
+        if((TYPETest(&vMyParticles[i], params.iType)
+            && TYPETest(&vMyParticles[i], params.iTypeWriting))
            || params.iBinaryOut != 6) {
             if(params.bFloat) {
                 if(params.bVector) {
-                    Vector3D<float> vec = params.vValue(&myParticles[i]);
+                    Vector3D<float> vec = params.vValue(&vMyParticles[i]);
                     xdr_template(&xdrs, &vec);
                     }
                 else {
-                    float dValue = params.dValue(&myParticles[i]);
+                    float dValue = params.dValue(&vMyParticles[i]);
                     xdr_float(&xdrs, &dValue);
                     }
                 }
             else {
                 if(params.iBinaryOut == 6) {
-                    int64_t iValue = params.iValue(&myParticles[i]);
+                    int64_t iValue = params.iValue(&vMyParticles[i]);
                     xdr_template(&xdrs, &iValue);
                     }
                 else {  // tipsy binary array only does 32 bit ints
-                    int iValue = params.iValue(&myParticles[i]);
+                    int iValue = params.iValue(&vMyParticles[i]);
                     xdr_template(&xdrs, &iValue);
                     }
                 }

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -514,7 +514,6 @@ mainmodule ParallelGravity {
     entry void startlb(const CkCallback &cb, int activeRung, bool bDoLB);
     entry void ResumeFromSync();
 
-    entry void minmaxNCOut(CkReference<OutputParams> params, const CkCallback& cb);
     entry void outputStatistics(const CkCallback& cb);
     entry void collectStatistics(const CkCallback &cb);
 
@@ -591,8 +590,9 @@ mainmodule ParallelGravity {
     entry void oneNodeOutArr(CkReference<OutputParams>, double adOut[nPart],
 			   int nPart, int iIndex, int bDone,
 			   const CkCallback& cb) ;
-   entry void oneNodeOutIntArr(CkReference<OutputParams>, int aiOut[nPart],
+    entry void oneNodeOutIntArr(CkReference<OutputParams>, int aiOut[nPart],
                                 int nPart, int iIndex, const CkCallback& cb);
+    entry void minmaxNCOut(CkReference<OutputParams> params, const CkCallback& cb);
   };
   array [1D] LvArray {
       entry LvArray();

--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -9,6 +9,7 @@ mainmodule ParallelGravity {
   readonly CProxy_Main mainChare;
   readonly int verbosity;
   readonly CProxy_TreePiece treeProxy;
+  readonly CProxy_Writer writeProxy;
 #ifdef REDUCTION_HELPER
   readonly CProxy_ReductionHelper reductionHelperProxy;
 #endif
@@ -313,49 +314,7 @@ mainmodule ParallelGravity {
     entry void RestartEnergy(double dTuFac, const CkCallback& cb);
     entry void findTotalMass(const CkCallback &cb);
     entry void recvTotalMass(CkReductionMsg *msg);
-    entry void setupWrite(int iStage, u_int64_t iPrevOffset,
-        const std::string& filename,
-        const double dTime, const double dvFac,
-        const double duTfac,
-        const bool bDoublePos,
-        const bool bDoubleVel,
-        const int bCool,
-        const CkCallback& cb);
-    entry void parallelWrite(int iPass, const CkCallback& cb,
-			   const std::string& filename, const double dTime,
-			   const double dvFac, // scale velocities
-			   const double duTFac, // convert temperature
-                           const bool bDoublePos,
-                           const bool bDoubleVel,
-			   const int bCool);
-    entry void serialWrite(u_int64_t iPrevOffset, const std::string& filename,
-        const double dTime, const double dvFac,
-        const double duTfac,
-        const bool bDoublePos,
-        const bool bDoubleVel,
-        const int bCool,
-        const CkCallback& cb);
-    entry void oneNodeWrite(int iIndex,
-			       int iOutParticles,
-			       int iOutSPH,
-			       int iOutStar,
-			       GravityParticle particles[iOutParticles+2], // particles to
-						     // write
-			       extraSPHData pGas[iOutSPH], // SPH data
-			       extraStarData pStar[iOutStar], // Star data
-			       int piSPH[iOutSPH], // SPH data offsets
-			       int piStar[iOutStar], // Star data offsets
-			       const u_int64_t iPrevOffset,
-			       const std::string& filename,  // output file
-			       const double dTime,      // time or expansion
-			       const double dvFac,  // velocity conversion
-			     const double duTFac, // temperature conversion
-                             const bool bDoublePos,
-                             const bool bDoubleVel,
-			     const int bCool, const CkCallback& cb);
-    entry void reOrder(int64_t nMaxOrder, const CkCallback& cb);
-    entry void ioShuffle(CkReductionMsg *msg);
-    entry void ioAcceptSortedParticles(ParticleShuffleMsg *);
+    entry void fillWriters(int64_t _nMaxOrder);
     entry void assignKeys(CkReductionMsg* m);
     entry [nokeep] void evaluateBoundaries(SFC::Key keys[n], const int n, int isRefine, const CkCallback& cb);
     entry void unshuffleParticles(CkReductionMsg* m);
@@ -555,20 +514,7 @@ mainmodule ParallelGravity {
     entry void startlb(const CkCallback &cb, int activeRung, bool bDoLB);
     entry void ResumeFromSync();
 
-    entry void outputASCII(CkReference<OutputParams>, int bParaWrite,
-			   const CkCallback& cb);
-    entry void oneNodeOutVec(CkReference<OutputParams>, Vector3D<double> avOut[nPart],
-			   int nPart, int iIndex, int bDone,
-			   const CkCallback& cb) ;
-    entry void oneNodeOutArr(CkReference<OutputParams>, double adOut[nPart],
-			   int nPart, int iIndex, int bDone,
-			   const CkCallback& cb) ;
-    entry void outputBinary(Ck::IO::Session, CkReference<OutputParams>);
     entry void minmaxNCOut(CkReference<OutputParams> params, const CkCallback& cb);
-    entry void outputBinaryStart(CkReference<OutputParams> params,
-                                 int64_t nStart, const CkCallback& cb);
-    entry void oneNodeOutIntArr(CkReference<OutputParams>, int aiOut[nPart],
-                                int nPart, int iIndex, const CkCallback& cb);
     entry void outputStatistics(const CkCallback& cb);
     entry void collectStatistics(const CkCallback &cb);
 
@@ -589,6 +535,65 @@ mainmodule ParallelGravity {
 
   };
 
+  group [migratable] Writer {
+    entry Writer();
+    entry void receive(std::vector<GravityParticle> vPart, std::vector<extraSPHData>,
+                 std::vector<extraStarData>);
+    entry void clear(int64_t nTotal, int64_t nSPH, int64_t nDark, int64_t nStar,
+               const CkCallback& cb);
+    entry void reOrder(const CkCallback& cb);
+    entry void setupWrite(int iStage, u_int64_t iPrevOffset,
+        const std::string& filename,
+        const double dTime, const double dvFac,
+        const double duTfac,
+        const bool bDoublePos,
+        const bool bDoubleVel,
+        const int bCool,
+        const CkCallback& cb);
+    entry void parallelWrite(int iPass, const CkCallback& cb,
+			   const std::string& filename, const double dTime,
+			   const double dvFac, // scale velocities
+			   const double duTFac, // convert temperature
+                           const bool bDoublePos,
+                           const bool bDoubleVel,
+			   const int bCool);
+    entry void serialWrite(u_int64_t iPrevOffset, const std::string& filename,
+        const double dTime, const double dvFac,
+        const double duTfac,
+        const bool bDoublePos,
+        const bool bDoubleVel,
+        const int bCool,
+        const CkCallback& cb);
+    entry void oneNodeWrite(int iIndex,
+			    int iOutSPH,
+			    int iOutStar,
+                            std::vector<GravityParticle> vMyParticles,
+			    std::vector<extraSPHData> vGas, // SPH data
+			    std::vector<extraStarData> vStar, // Star data
+			       int piSPH[iOutSPH], // SPH data offsets
+			       int piStar[iOutStar], // Star data offsets
+			       const u_int64_t iPrevOffset,
+			       const std::string& filename,  // output file
+			       const double dTime,      // time or expansion
+			       const double dvFac,  // velocity conversion
+			     const double duTFac, // temperature conversion
+                             const bool bDoublePos,
+                             const bool bDoubleVel,
+			     const int bCool, const CkCallback& cb);
+    entry void outputBinary(Ck::IO::Session, CkReference<OutputParams>);
+    entry void outputBinaryStart(CkReference<OutputParams> params,
+                                 int64_t nStart, const CkCallback& cb);
+    entry void outputASCII(CkReference<OutputParams>, int bParaWrite,
+			   const CkCallback& cb);
+    entry void oneNodeOutVec(CkReference<OutputParams>, Vector3D<double> avOut[nPart],
+			   int nPart, int iIndex, int bDone,
+			   const CkCallback& cb) ;
+    entry void oneNodeOutArr(CkReference<OutputParams>, double adOut[nPart],
+			   int nPart, int iIndex, int bDone,
+			   const CkCallback& cb) ;
+   entry void oneNodeOutIntArr(CkReference<OutputParams>, int aiOut[nPart],
+                                int nPart, int iIndex, const CkCallback& cb);
+  };
   array [1D] LvArray {
       entry LvArray();
   };

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -66,6 +66,7 @@ CProxy_Main mainChare;
 int verbosity;
 int bVDetails;
 CProxy_TreePiece treeProxy; ///< Proxy for the TreePiece chare array
+CProxy_Writer writeProxy; ///< proxy for Writer Group
 #ifdef REDUCTION_HELPER
 CProxy_ReductionHelper reductionHelperProxy;
 #endif
@@ -1374,6 +1375,7 @@ Main::Main(CkArgMsg* m) {
         prjgrp = CProxy_ProjectionsControl::ckNew();
 
 	treeProxy = pieces;
+        writeProxy = CProxy_Writer::ckNew();
 #ifdef REDUCTION_HELPER
         reductionHelperProxy = CProxy_ReductionHelper::ckNew();
 #endif
@@ -3228,10 +3230,7 @@ Main::doSimulation()
           ckout << " took " << (CkWallTimer() - startTime) << " seconds." << endl;
 #endif
 	  treeProxy.finishNodeCache(CkCallbackResumeThread());
-          ckout << "Reordering ...";
-          startTime = CkWallTimer();
-	  treeProxy.reOrder(nMaxOrder, CkCallbackResumeThread());
-          ckout << " took " << (CkWallTimer() - startTime) << " seconds." << endl;
+          reOrder();
           if(param.iBinaryOut == 6) {
               // Set up N-Chilada directory structure
               CkMustAssert(safeMkdir(achFile.c_str()) == 0, "Can't create N-Chilada directories\n");
@@ -3254,7 +3253,7 @@ Main::doSimulation()
           if(param.iBinaryOut)
               outputBinary(pDenOut, param.bParaWrite, CkCallbackResumeThread());
           else
-              treeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
+              writeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
 	  ckout << " took " << (CkWallTimer() - startTime) << " seconds."
 		<< endl;
 	  ckout << "Outputting hsmooth ...";
@@ -3262,10 +3261,10 @@ Main::doSimulation()
           if(param.iBinaryOut)
               outputBinary(pHsmOut, param.bParaWrite, CkCallbackResumeThread());
           else
-              treeProxy[0].outputASCII(pHsmOut, param.bParaWrite, CkCallbackResumeThread());
+              writeProxy[0].outputASCII(pHsmOut, param.bParaWrite, CkCallbackResumeThread());
 	  }
       else {
-	  treeProxy.reOrder(nMaxOrder, CkCallbackResumeThread());
+          reOrder();
 	  }
 
       writeOutput(0);
@@ -3323,23 +3322,23 @@ Main::doSimulation()
                   }
               else {
 #ifdef SUPERBUBBLE
-                  treeProxy[0].outputASCII(pmHotOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(puHotOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(puOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pTeffOut, param.bParaWrite,CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pmHotOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(puHotOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(puOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pTeffOut, param.bParaWrite,CkCallbackResumeThread());
 #endif
-                  treeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pPresOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pSphHOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pDivVOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pPDVOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pMuMaxOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pBSwOut, param.bParaWrite, CkCallbackResumeThread());
-                  treeProxy[0].outputASCII(pCsOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pPresOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pSphHOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pDivVOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pPDVOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pMuMaxOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pBSwOut, param.bParaWrite, CkCallbackResumeThread());
+                  writeProxy[0].outputASCII(pCsOut, param.bParaWrite, CkCallbackResumeThread());
 #ifndef COOLING_NONE
                   if(param.bGasCooling) {
                       EDotOutputParams pEDotOut(achFile, 0, 0.0);
-                      treeProxy[0].outputASCII(pEDotOut, param.bParaWrite,
+                      writeProxy[0].outputASCII(pEDotOut, param.bParaWrite,
 					   CkCallbackResumeThread());
                       }
 #endif
@@ -3350,7 +3349,7 @@ Main::doSimulation()
       if(param.iBinaryOut)
           outputBinary(pAcc, param.bParaWrite, CkCallbackResumeThread());
       else
-          treeProxy[0].outputASCII(pAcc, param.bParaWrite, CkCallbackResumeThread());
+          writeProxy[0].outputASCII(pAcc, param.bParaWrite, CkCallbackResumeThread());
 #ifdef NEED_DT
       ckout << "Outputting dt ...";
       adjust(0);
@@ -3358,7 +3357,7 @@ Main::doSimulation()
       if(param.iBinaryOut)
           outputBinary(pDt, param.bParaWrite, CkCallbackResumeThread());
       else
-          treeProxy[0].outputASCII(pDt, param.bParaWrite, CkCallbackResumeThread());
+          writeProxy[0].outputASCII(pDt, param.bParaWrite, CkCallbackResumeThread());
 #endif
       RungOutputParams pRung(achFile, param.iBinaryOut, 0.0);
       KeyOutputParams pKey(achFile, param.iBinaryOut, 0.0);
@@ -3369,9 +3368,9 @@ Main::doSimulation()
           outputBinary(pDomain, param.bParaWrite, CkCallbackResumeThread());
           }
       else {
-          treeProxy[0].outputASCII(pRung, param.bParaWrite, CkCallbackResumeThread());
-          treeProxy[0].outputASCII(pKey, param.bParaWrite, CkCallbackResumeThread());
-          treeProxy[0].outputASCII(pDomain, param.bParaWrite, CkCallbackResumeThread());
+          writeProxy[0].outputASCII(pRung, param.bParaWrite, CkCallbackResumeThread());
+          writeProxy[0].outputASCII(pKey, param.bParaWrite, CkCallbackResumeThread());
+          writeProxy[0].outputASCII(pDomain, param.bParaWrite, CkCallbackResumeThread());
           }
       if(param.bDoGas && param.bDoDensity) {
 	  // The following call is to get the particles in key order
@@ -3394,17 +3393,14 @@ Main::doSimulation()
 	  treeProxy.startReSmooth(&pDen, CkCallbackResumeThread());
           ckout << " took " << (CkWallTimer() - startTime) << " seconds." << endl;
 	  treeProxy.finishNodeCache(CkCallbackResumeThread());
-          ckout << "Reodering ...";
-          startTime = CkWallTimer();
-	  treeProxy.reOrder(nMaxOrder, CkCallbackResumeThread());
-          ckout << " took " << (CkWallTimer() - startTime) << " seconds." << endl;
+          reOrder();
 	  ckout << "Outputting densities ...";
 	  startTime = CkWallTimer();
 	  DenOutputParams pDenOut(achFile, param.iBinaryOut, 0.0);
           if(param.iBinaryOut)
               outputBinary(pDenOut, param.bParaWrite, CkCallbackResumeThread());
           else
-              treeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
+              writeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
 	  ckout << " took " << (CkWallTimer() - startTime) << " seconds."
 		<< endl;
 	  ckout << "Outputting hsmooth ...";
@@ -3412,7 +3408,7 @@ Main::doSimulation()
           if(param.iBinaryOut)
               outputBinary(pHsmOut, param.bParaWrite, CkCallbackResumeThread());
           else
-              treeProxy[0].outputASCII(pHsmOut, param.bParaWrite, CkCallbackResumeThread());
+              writeProxy[0].outputASCII(pHsmOut, param.bParaWrite, CkCallbackResumeThread());
 	  }
   }
 
@@ -3678,15 +3674,7 @@ void Main::writeOutput(int iStep)
 	dvFac = 1.0;
 	}
     
-    if(verbosity) {
-	ckout << "ReOrder particles ...";
-	startTime = CkWallTimer();
-	}
-    
-    treeProxy.reOrder(nMaxOrder, CkCallbackResumeThread());
-    if(verbosity)
-	ckout << " took " << (CkWallTimer() - startTime) << " seconds."
-	      << endl;
+    reOrder();
 
     double duTFac = (param.dConstGamma-1)*param.dMeanMolWeight/param.dGasConst;
     
@@ -3702,11 +3690,11 @@ void Main::writeOutput(int iStep)
             }
 
         if(param.bParaWrite)
-            treeProxy.setupWrite(0, 0, achFile, dOutTime, dvFac, duTFac,
+            writeProxy.setupWrite(0, 0, achFile, dOutTime, dvFac, duTFac,
                                  param.bDoublePos, param.bDoubleVel,
                                  param.bGasCooling, CkCallbackResumeThread());
         else
-            treeProxy[0].serialWrite(0, achFile, dOutTime, dvFac, duTFac,
+            writeProxy[0].serialWrite(0, achFile, dOutTime, dvFac, duTFac,
                                      param.bDoublePos, param.bDoubleVel,
                                      param.bGasCooling, CkCallbackResumeThread());
         }
@@ -3892,76 +3880,76 @@ void Main::writeOutput(int iStep)
             }
 	} else {
 #ifdef CULLENALPHA
-        treeProxy[0].outputASCII(pAlphaOut, param.bParaWrite,
+        writeProxy[0].outputASCII(pAlphaOut, param.bParaWrite,
                                CkCallbackResumeThread());
-        treeProxy[0].outputASCII(pDvDsOut, param.bParaWrite,
+        writeProxy[0].outputASCII(pDvDsOut, param.bParaWrite,
                                CkCallbackResumeThread());
 #endif
 	if (param.bStarForm || param.bFeedback) {
 #ifdef SUPERBUBBLE
-      treeProxy[0].outputASCII(pmHotOut, param.bParaWrite, CkCallbackResumeThread());
-      treeProxy[0].outputASCII(puHotOut, param.bParaWrite, CkCallbackResumeThread());
-      treeProxy[0].outputASCII(puOut, param.bParaWrite, CkCallbackResumeThread());
-      treeProxy[0].outputASCII(pTeffOut, param.bParaWrite,CkCallbackResumeThread());
+      writeProxy[0].outputASCII(pmHotOut, param.bParaWrite, CkCallbackResumeThread());
+      writeProxy[0].outputASCII(puHotOut, param.bParaWrite, CkCallbackResumeThread());
+      writeProxy[0].outputASCII(puOut, param.bParaWrite, CkCallbackResumeThread());
+      writeProxy[0].outputASCII(pTeffOut, param.bParaWrite,CkCallbackResumeThread());
 #endif
-        treeProxy[0].outputASCII(pRung, param.bParaWrite,
+        writeProxy[0].outputASCII(pRung, param.bParaWrite,
                                  CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pOxOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pOxOut, param.bParaWrite,
 				     CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pFeOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pFeOut, param.bParaWrite,
 				     CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pMFormOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pMFormOut, param.bParaWrite,
 				      CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pcoolontimeOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pcoolontimeOut, param.bParaWrite,
 				     CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pESNRateOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pESNRateOut, param.bParaWrite,
 				      CkCallbackResumeThread());
     }
 #ifndef COOLING_NONE
 	if(param.bGasCooling) {
-	    treeProxy[0].outputASCII(pCool0Out, param.bParaWrite,
+	    writeProxy[0].outputASCII(pCool0Out, param.bParaWrite,
 				     CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pCool1Out, param.bParaWrite,
+	    writeProxy[0].outputASCII(pCool1Out, param.bParaWrite,
 				     CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pCool2Out, param.bParaWrite,
+	    writeProxy[0].outputASCII(pCool2Out, param.bParaWrite,
 				     CkCallbackResumeThread());
 #ifdef COOLING_MOLECULARH
-	    treeProxy[0].outputASCII(pCool3Out, param.bParaWrite,
+	    writeProxy[0].outputASCII(pCool3Out, param.bParaWrite,
 				     CkCallbackResumeThread());
 #endif /*COOLING_MOLECULARH*/
 	}
 #ifdef COOLING_MOLECULARH
 	if(param.bDoStellarLW)
-	  treeProxy[0].outputASCII(pLWOut, param.bParaWrite,
+	  writeProxy[0].outputASCII(pLWOut, param.bParaWrite,
 				   CkCallbackResumeThread());  
 #ifdef SHIELDSF
-        treeProxy[0].outputASCII(pShieldOut, param.bParaWrite,
+        writeProxy[0].outputASCII(pShieldOut, param.bParaWrite,
                                  CkCallbackResumeThread());  
 #endif
 #endif /*COOLING_MOLECULARH*/
 #endif
 #ifdef DIFFUSION
         if (param.bStarForm || param.bFeedback) {
-            treeProxy[0].outputASCII(pMetalsDotOut, param.bParaWrite,
+            writeProxy[0].outputASCII(pMetalsDotOut, param.bParaWrite,
                                      CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pOxDotOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pOxDotOut, param.bParaWrite,
 				     CkCallbackResumeThread());
-	    treeProxy[0].outputASCII(pFeDotOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pFeDotOut, param.bParaWrite,
 				     CkCallbackResumeThread());
 	    }
 #endif
 	if(param.bDoSoftOutput)
-	    treeProxy[0].outputASCII(pSoftOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pSoftOut, param.bParaWrite,
 				      CkCallbackResumeThread());
 	if(param.bDohOutput)
-	    treeProxy[0].outputASCII(pHsmOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pHsmOut, param.bParaWrite,
 				     CkCallbackResumeThread());
 	if(param.bDoCSound)
-	    treeProxy[0].outputASCII(pCSOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pCSOut, param.bParaWrite,
 				      CkCallbackResumeThread());
 	if(param.bDoIOrderOutput || param.bStarForm || param.bFeedback) {
 	    IOrderOutputParams pIOrdOut(achFile, param.iBinaryOut, dOutTime);
-	    treeProxy[0].outputASCII(pIOrdOut, param.bParaWrite,
+	    writeProxy[0].outputASCII(pIOrdOut, param.bParaWrite,
 					CkCallbackResumeThread());
         if(param.bDoGas 
 #ifndef SPLITGAS
@@ -3971,7 +3959,7 @@ void Main::writeOutput(int iStep)
         {
 		IGasOrderOutputParams pIGasOrdOut(achFile, param.iBinaryOut,
                     dOutTime);
-		treeProxy[0].outputASCII(pIGasOrdOut, param.bParaWrite,
+		writeProxy[0].outputASCII(pIGasOrdOut, param.bParaWrite,
 					    CkCallbackResumeThread());
 	      }
 	  }
@@ -3979,7 +3967,7 @@ void Main::writeOutput(int iStep)
         if(param.iSIDMSelect!=0) {
 #ifdef SIDMINTERACT
             iNSIDMOutputParams pNSIDMOut(achFile, param.iBinaryOut, dOutTime);
-            treeProxy[0].outputASCII(pNSIDMOut, param.bParaWrite,
+            writeProxy[0].outputASCII(pNSIDMOut, param.bParaWrite,
                                           CkCallbackResumeThread());
 #endif
             }
@@ -4004,16 +3992,10 @@ void Main::writeOutput(int iStep)
 	treeProxy.startSmooth(&pDen, 1, param.nSmooth, dfBall2OverSoft2,
 			      CkCallbackResumeThread());
 	treeProxy.finishNodeCache(CkCallbackResumeThread());
+
+        reOrder();
+        
 	if(verbosity) {
-	    ckout << " took " << (CkWallTimer() - startTime) << " seconds."
-		  << endl;
-	    ckout << "Reodering ...";
-	    }
-	startTime = CkWallTimer();
-	treeProxy.reOrder(nMaxOrder, CkCallbackResumeThread());
-	if(verbosity) {
-	    ckout << " took " << (CkWallTimer() - startTime) << " seconds."
-		  << endl;
 	    ckout << "Outputting densities ...";
 	    }
 	startTime = CkWallTimer();
@@ -4021,7 +4003,7 @@ void Main::writeOutput(int iStep)
 	if (param.iBinaryOut)
 	    outputBinary(pDenOut, param.bParaWrite, CkCallbackResumeThread());
 	else
-	    treeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
+	    writeProxy[0].outputASCII(pDenOut, param.bParaWrite, CkCallbackResumeThread());
 	ckout << " took " << (CkWallTimer() - startTime) << " seconds."
 	      << endl;
 
@@ -4662,6 +4644,8 @@ void printTreeGraphViz(GenericTreeNode *node, ostream &out, const string &name){
   out << "}" << endl;
 }
 
+
+#include "Writer.h"
 
 #include "ParallelGravity.def.h"
 

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1956,8 +1956,6 @@ public:
     int shufflelen);
 	void ResumeFromSync();
 
-        void minmaxNCOut(OutputParams& params, const CkCallback& cb);
-
 	void outputStatistics(const CkCallback& cb);
 	/// Collect the total statistics from the various chares
         void collectStatistics(const CkCallback &cb);

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -153,6 +153,7 @@ extern double dGlassDamper;
 extern int bUseCkLoopPar;
 extern GenericTrees useTree;
 extern CProxy_TreePiece treeProxy;
+extern CProxy_Writer writeProxy;
 #ifdef REDUCTION_HELPER
 extern CProxy_ReductionHelper reductionHelperProxy;
 #endif
@@ -586,6 +587,7 @@ public:
 	void getStartTime();
 	void getOutTimes();
 	int bOutTime();
+        void reOrder();
 	void writeOutput(int iStep) ;
         void outputBinary(OutputParams& params, int bParaWrite,
                           const CkCallback& cb);
@@ -1159,12 +1161,6 @@ private:
 	/// holds the total mass of the current TreePiece
 	double piecemass;
 
-	/// used to determine which coordinate we are outputting, while printing
-	/// accelerations in ASCII format
-	int cnt;
-	/// used to determine if the x, y, z coordinates should be printed
-	/// together while outputting accelerations in ASCII format
-	int packed;
 
           // the index assigned by the CacheManager upon registration
           int localIndex;
@@ -1237,10 +1233,6 @@ private:
 #endif
         /// indices of my newly formed particles in the starlog table
         std::vector<int> iSeTab;
-	/// Setup for writing
-	int nSetupWriteStage;
-	int64_t nStartWrite;	// Particle number at which this piece starts
-				// to write file.
 
 	/// Map between Keys and TreeNodes, used to get a node from a key
 	NodeLookupType nodeLookupTable;
@@ -1448,7 +1440,6 @@ public:
 	  nPartCacheEntries = 0;
 	  completedActiveWalks = 0;
 	  myPlace = -1;
-	  nSetupWriteStage = -1;
     //openingDiffCount=0;
     chunkRootLevel=0;
     //splitters = NULL;
@@ -1462,9 +1453,6 @@ public:
 
 	  piecemass = 0.0;
 #endif
-	  packed=0;			/* output accelerations in x,y,z
-					   packed format */
-	  cnt=0;			/* Counter over x,y,z when not packed */
 	  particleInterRemote = NULL;
 	  nodeInterRemote = NULL;
 
@@ -1546,7 +1534,6 @@ public:
           incomingParticlesArrived = 0;
           incomingParticlesSelf = false;
 
-	  cnt=0;
 	  nodeInterRemote = NULL;
           particleInterRemote = NULL;
 
@@ -1634,61 +1621,7 @@ public:
         void findTotalMass(const CkCallback &cb);
         void recvTotalMass(CkReductionMsg *msg);
 
-	// Write a Tipsy file
-	void writeTipsy(Tipsy::TipsyWriter& w,
-			const double dvFac, // scale velocities
-			const double duTFac, // convert temperature
-                        const bool bDoublePos,
-                        const bool bDoubleVel,
-			const int bCool);
-	// Find position in the file to start writing
-	void setupWrite(int iStage, u_int64_t iPrevOffset,
-			const std::string& filename, const double dTime,
-			const double dvFac, const double duTFac,
-                        const bool bDoublePos,
-                        const bool bDoubleVel,
-			const int bCool, const CkCallback& cb);
-	// control parallelism in the write
-	void parallelWrite(int iPass, const CkCallback& cb,
-			   const std::string& filename, const double dTime,
-			   const double dvFac, // scale velocities
-			   const double duTFac, // convert temperature
-                           const bool bDoublePos,
-                           const bool bDoubleVel,
-			   const int bCool);
-	// serial output
-	void serialWrite(u_int64_t iPrevOffset, const std::string& filename,
-			 const double dTime,
-			 const double dvFac, const double duTFac,
-                         const bool bDoublePos,
-                         const bool bDoubleVel,
-			 const int bCool, const CkCallback& cb);
-	// setup for serial output
-	void oneNodeWrite(int iIndex,
-			       int iOutParticles,
-			       int iOutSPH,
-			       int iOutStar,
-			       GravityParticle *particles, // particles to
-						     // write
-			       extraSPHData *pGas, // SPH data
-			       extraStarData *pStar, // Star data
-			       int *piSPH, // SPH data offsets
-			       int *piStar, // Star data offsets
-			       const u_int64_t iPrevOffset,
-			       const std::string& filename,  // output file
-			       const double dTime,      // time or expansion
-			       const double dvFac,  // velocity conversion
-			     const double duTFac, // temperature
-						  // conversion
-                           const bool bDoublePos,
-                           const bool bDoubleVel,
-			  const int bCool,
-			  const CkCallback &cb);
-	// Reorder for output
-        void reOrder(int64_t nMaxOrder, const CkCallback& cb);
-	// move particles around for output
-	void ioShuffle(CkReductionMsg *msg);
-	void ioAcceptSortedParticles(ParticleShuffleMsg *);
+        void fillWriters(int64_t _nMaxOrder);
         /// @brief Set the load balancing data after a restart from
         /// checkpoint.
         void resetObjectLoad(const CkCallback& cb);
@@ -2023,19 +1956,6 @@ public:
     int shufflelen);
 	void ResumeFromSync();
 
-	void outputASCII(OutputParams& params, int bParaWrite,
-			 const CkCallback& cb);
-	void oneNodeOutVec(OutputParams& params, Vector3D<double>* avOut,
-			   int nPart, int iIndex, int bDone,
-			   const CkCallback& cb) ;
-	void oneNodeOutArr(OutputParams& params, double* adOut,
-			   int nPart, int iIndex, int bDone,
-			   const CkCallback& cb) ;
-	void oneNodeOutIntArr(OutputParams& params, int *aiOut,
-                              int nPart, int iIndex, const CkCallback& cb);
-        void outputBinaryStart(OutputParams& params, int64_t nStart,
-                               const CkCallback& cb);
-	void outputBinary(Ck::IO::Session, OutputParams& params);
         void minmaxNCOut(OutputParams& params, const CkCallback& cb);
 
 	void outputStatistics(const CkCallback& cb);

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -5851,8 +5851,6 @@ void TreePiece::pup(PUP::er& p) {
   p | boundingBox;
   p | iterationNo;
 
-  p | nSetupWriteStage;
-
   p | rndGen;
 
   // Periodic variables
@@ -5882,7 +5880,6 @@ void TreePiece::pup(PUP::er& p) {
   p | numOpenCriterionCalls;
   p | piecemass;
 #endif
-  p | packed;
 
   if (p.isUnpacking()) {
     particleInterRemote = NULL;

--- a/Writer.h
+++ b/Writer.h
@@ -109,6 +109,7 @@ public:
                        const CkCallback& cb) ;
     void oneNodeOutIntArr(OutputParams& params, int *aiOut,
                           int nPart, int iIndex, const CkCallback& cb);
+    void minmaxNCOut(OutputParams& params, const CkCallback& cb);
     void outputBinary(Ck::IO::Session session, OutputParams& params);
     void outputBinaryStart(OutputParams& params, int64_t nStart,
                            const CkCallback& cb);

--- a/Writer.h
+++ b/Writer.h
@@ -1,0 +1,125 @@
+/** @file Writer.h
+    The Writer group holds a copy of the particles before they are
+    written to disk.  It sorts them and writes the requested files.
+*/
+#ifndef _WRITER_H_
+#define _WRITER_H_
+
+#include <vector>
+#include "ParallelGravity.decl.h"
+
+class Writer : public CBase_Writer {
+public:
+    
+private:
+    std::vector<GravityParticle> vMyParticles;
+    std::vector<extraSPHData> vMySPHParticles;
+    std::vector<extraStarData> vMyStarParticles;
+    int64_t nTotalParticles;
+    int64_t nTotalSPH;
+    int64_t nTotalDark;
+    int64_t nTotalStar;
+    /// A local pointer to my DataManager.
+    DataManager* dm;
+    /// Setup for writing
+    int nSetupWriteStage;
+    int64_t nStartWrite;	// Particle number at which this piece starts
+				// to write file.
+    /// used to determine which coordinate we are outputting, while printing
+    /// accelerations in ASCII format
+    int cnt;
+    /// used to determine if the x, y, z coordinates should be printed
+    /// together while outputting accelerations in ASCII format
+    int packed;
+public:
+    Writer() {
+        nStartWrite = -1;
+        nSetupWriteStage = -1;
+        packed=0;			/* output accelerations in x,y,z
+					   packed format */
+        cnt=0;			/* Counter over x,y,z when not packed */
+    }
+    Writer(CkMigrateMessage *m) : CBase_Writer(m) {
+        nStartWrite = -1;
+        nSetupWriteStage = -1;
+        packed=0;
+        cnt=0;
+    }
+    void pup(PUP::er &p){
+        CBase_Writer::pup(p);
+    }
+    
+    void init(const CkCallback& cb);
+    void receive(std::vector<GravityParticle> vPart, std::vector<extraSPHData>,
+                 std::vector<extraStarData>);
+    void clear(int64_t nTotal, int64_t nSPH, int64_t nDark, int64_t nStar,
+               const CkCallback& cb);
+    void reOrder(const CkCallback &cb);
+	// control parallelism in the write
+	void parallelWrite(int iPass, const CkCallback& cb,
+			   const std::string& filename, const double dTime,
+			   const double dvFac, // scale velocities
+			   const double duTFac, // convert temperature
+                           const bool bDoublePos,
+                           const bool bDoubleVel,
+			   const int bCool);
+	// serial output
+	void serialWrite(u_int64_t iPrevOffset, const std::string& filename,
+			 const double dTime,
+			 const double dvFac, const double duTFac,
+                         const bool bDoublePos,
+                         const bool bDoubleVel,
+			 const int bCool, const CkCallback& cb);
+	// setup for serial output
+	void oneNodeWrite(int iIndex,
+                          int iOutSPH,
+                          int iOutStar,
+                          std::vector<GravityParticle> vParticles, // particles to write
+                          std::vector<extraSPHData> vGas, // SPH data
+                          std::vector<extraStarData> vStar, // Star data
+                          int *piSPH, // SPH data offsets
+                          int *piStar, // Star data offsets
+                          const u_int64_t iPrevOffset,
+                          const std::string& filename,  // output file
+                          const double dTime,      // time or expansion
+                          const double dvFac,  // velocity conversion
+                          const double duTFac, // temperature
+						  // conversion
+                          const bool bDoublePos,
+                          const bool bDoubleVel,
+			  const int bCool,
+			  const CkCallback &cb);
+    void setupWrite(int iStage, // stage of scan
+                    u_int64_t iPrevOffset,
+                    const std::string& filename,
+                    const double dTime,
+                    const double dvFac,
+                    const double duTFac,
+                    const bool bDoublePos,
+                    const bool bDoubleVel,
+                    const int bCool,
+                    const CkCallback& cb);
+    void outputASCII(OutputParams& params, int bParaWrite,
+                     const CkCallback& cb);
+    void oneNodeOutVec(OutputParams& params, Vector3D<double>* avOut,
+                       int nPart, int iIndex, int bDone,
+                       const CkCallback& cb) ;
+    void oneNodeOutArr(OutputParams& params, double* adOut,
+                       int nPart, int iIndex, int bDone,
+                       const CkCallback& cb) ;
+    void oneNodeOutIntArr(OutputParams& params, int *aiOut,
+                          int nPart, int iIndex, const CkCallback& cb);
+    void outputBinary(Ck::IO::Session session, OutputParams& params);
+    void outputBinaryStart(OutputParams& params, int64_t nStart,
+                           const CkCallback& cb);
+    void writeTipsy(Tipsy::TipsyWriter& w,
+                    std::vector<GravityParticle>& vParticles,
+                    const double dvFac, // scale velocities
+                    const double duTFac, // convert temperature
+                    const bool bDoublePos,
+                    const bool bDoubleVel,
+                    const int bCool);
+};
+
+
+#endif /* _WRITER_H_ */

--- a/Writer.h
+++ b/Writer.h
@@ -8,22 +8,27 @@
 #include <vector>
 #include "ParallelGravity.decl.h"
 
+/// @brief Per-processor element of the Writer charm group.
 class Writer : public CBase_Writer {
-public:
-    
 private:
+    /// Storage for the particle data to be written by this group.
     std::vector<GravityParticle> vMyParticles;
     std::vector<extraSPHData> vMySPHParticles;
     std::vector<extraStarData> vMyStarParticles;
+    /// Total particles in the entire simulation; needed for writing
+    /// file headers.
     int64_t nTotalParticles;
+    /// Total SPH particles for file header.
     int64_t nTotalSPH;
+    /// Total dark particles for file header.
     int64_t nTotalDark;
+    /// Total star particles for file header.
     int64_t nTotalStar;
-    /// A local pointer to my DataManager.
+    /// A local pointer to my DataManager.for cooling information
     DataManager* dm;
     /// Setup for writing
     int nSetupWriteStage;
-    int64_t nStartWrite;	// Particle number at which this piece starts
+    int64_t nStartWrite;	// Particle number at which this element starts
 				// to write file.
     /// used to determine which coordinate we are outputting, while printing
     /// accelerations in ASCII format


### PR DESCRIPTION
Advantages:
1) Fewer writers
2) Fewer shuffling messages to get particles in output order.
3) No messages to get particles back in simulation order.

I expect this to greatly reduce the number of messages needed for I/O, as well as the memory use.  It should also reduce the stress on file systems when writing Tipsy files.
