### PR TITLE
Implement single stepping: all particles on the minimum timestep.

### DIFF
--- a/ParallelGravity.ci
+++ b/ParallelGravity.ci
@@ -371,6 +371,7 @@ mainmodule ParallelGravity {
 	      const CkCallback& cb);
 #endif
     entry void truncateRung(int iCurrMaxRung, const CkCallback& cb);
+    entry void SingleStep(int iCurrMaxRung, int iKickRung, const CkCallback &cb);
     entry void rungStats(const CkCallback& cb);
     entry void countActive(int activeRung, const CkCallback& cb);
     entry void countType(int iType, const CkCallback& cb);

--- a/ParallelGravity.cpp
+++ b/ParallelGravity.cpp
@@ -293,6 +293,10 @@ Main::Main(CkArgMsg* m) {
         prmAddParam(prm, "killAt", paramInt, &killAt,
 		    sizeof(int),"killat", "Stop the simulation after this step");
 
+        param.bSingleStep = 0;
+        prmAddParam(prm,"bSingleStep",paramBool,&param.bSingleStep,
+                    sizeof(int), "sstep",
+                    "Single stepping: all particles use the same timestep");
 	param.bEpsAccStep = 1;
 	prmAddParam(prm, "bEpsAccStep", paramBool, &param.bEpsAccStep,
 		    sizeof(int),"epsacc", "Use sqrt(eps/a) timestepping");
@@ -4043,6 +4047,10 @@ int Main::adjust(int iKickRung)
             iCurrSinkRung = iCurrMaxRungGas;
         treeProxy.SinkStep(iCurrSinkRung, iKickRung, CkCallbackResumeThread());
         }
+    if(param.bSingleStep) {
+        treeProxy.SingleStep(iCurrMaxRung, iKickRung, CkCallbackResumeThread());
+    }
+
     delete msg;
     double tAdjust = CkWallTimer() - startTime;
     timings[iKickRung].tAdjust += tAdjust;

--- a/ParallelGravity.h
+++ b/ParallelGravity.h
@@ -1719,6 +1719,7 @@ public:
    * @param cb callback.
    */
   void truncateRung(int iCurrMaxRung, const CkCallback& cb);
+  void SingleStep(int iCurrMaxRung, int iKickRung, const CkCallback &cb);
   void rungStats(const CkCallback& cb);
   void countActive(int activeRung, const CkCallback& cb);
   /// @brief count total number of particles of given type

--- a/TreePiece.cpp
+++ b/TreePiece.cpp
@@ -1918,6 +1918,24 @@ void TreePiece::truncateRung(int iCurrMaxRung, const CkCallback& cb) {
     contribute(cb);
     }
 
+/// @brief Set all particles to the same timestep, if appropriate
+///
+/// @param iCurrMaxRung The rung to set particle timesteps
+/// @param iKickRung    Timesteps can only be modified when being kicked
+/// @param cb           Callback when complete.
+///
+void TreePiece::SingleStep(int iCurrMaxRung, int iKickRung,
+                           const CkCallback &cb)
+{
+    for(unsigned int i = 1; i <= myNumParticles; ++i) {
+        GravityParticle *p = &myParticles[i];
+        if(p->rung >= iKickRung) {
+           p->rung = iCurrMaxRung;
+       }
+    }
+    contribute(cb);
+}
+
 void TreePiece::rungStats(const CkCallback& cb) {
   int64_t nInRung[MAXRUNG+1];
 

--- a/parameters.h
+++ b/parameters.h
@@ -27,6 +27,7 @@ typedef struct parameters {
     int iStartStep;
     int iWallRunTime;
     double dDelta;
+    int bSingleStep;            /* All particles use the smallest timestep */
     int bEpsAccStep;
     int bGravStep;
     int bKepStep;
@@ -182,6 +183,7 @@ inline void operator|(PUP::er &p, Parameters &param) {
     p|param.iStartStep;
     p|param.iWallRunTime;
     p|param.dDelta;
+    p|param.bSingleStep;
     p|param.bEpsAccStep;
     p|param.bGravStep;
     p|param.bKepStep;


### PR DESCRIPTION
This adds a boolean parameter to force all particles to the smallest timestep as determined by the timestep criteria.
