### PR TITLE
configure: warns no utility package

### DIFF
--- a/configure
+++ b/configure
@@ -2352,6 +2352,22 @@ USER_LDFLAGS=$LDFLAGS
 
 if test "x$STRUCT_DIR" = "x"; then
 	STRUCT_DIR=$srcdir/../utility/structures
+	if [ ! -d $STRUCT_DIR ]; then
+	    echo 
+	    echo "WARNING!  STRUCT_DIR points to $STRUCT_DIR"
+	    echo "which does not exist.  This may mean you have"
+	    echo "not installed the N-BodyShop 'utility' package."
+	    echo "Without that package, your ChaNGa configure will fail."
+	    echo
+	    # As far as I can see, if it gets past this point and
+	    # STRUC_DIR doesn't point to anything valid, then the configure will
+	    # fail at the point where it tries to pull the Makefile.in from the
+	    # utility directory to build the Makefile.  So I would configure it to
+	    # fail and exit here rather than continuing, so that the user would definitely
+	    # see the warning, but I think whether to include the exit or not is a matter
+	    # of build style/policy.  
+	    exit
+	fi
 fi
 
 


### PR DESCRIPTION
In configure: after setting STRUCT_DIR to the default, checks to see if that exists. If it doesn't sends a warning that "uiltity" package probably missing and exits.  

I realize I was very verbose in my comment, but this is the kind of error message I like to see when I'm trying to use something.  I think it's helpful to see a message that says "it looks like you were trying to do X.  However, you set THIS_VARIABLE to Y, which almost certainly won't work.  You need to point it to the directory that contains libIMPORTANT_LIBRARY.so".  You will likely want to edit it.  

I went ahead and ended it with "exit".  That way, if the utility directory exists, it doesn't bother to run the rest of the checks, because it will definitely fail at the "create Makefile" stage, but the warning will be at the top and may not be obvious.  